### PR TITLE
feat: add base migrations

### DIFF
--- a/database/migrations/2025_08_26_000000_create_users_table.php
+++ b/database/migrations/2025_08_26_000000_create_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('profile_picture_url')->nullable();
+            $table->string('phone_number')->nullable();
+            $table->string('password_hash');
+            $table->timestamp('email_verified_at')->nullable();
+            $table->rememberToken();
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->useCurrent()->useCurrentOnUpdate();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+};

--- a/database/migrations/2025_08_26_000100_create_groups_table.php
+++ b/database/migrations/2025_08_26_000100_create_groups_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('groups', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->uuid('owner_id');
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->foreign('owner_id')->references('id')->on('users')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('groups');
+    }
+};

--- a/database/migrations/2025_08_26_000200_create_payments_table.php
+++ b/database/migrations/2025_08_26_000200_create_payments_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('payments', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('payer_id');
+            $table->uuid('receiver_id');
+            $table->decimal('amount', 10, 2);
+            $table->string('payment_method');
+            $table->string('proof_url')->nullable();
+            $table->text('signature')->nullable();
+            $table->string('status')->default('pending');
+            $table->timestamp('payment_date')->useCurrent();
+
+            $table->foreign('payer_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->foreign('receiver_id')->references('id')->on('users')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payments');
+    }
+};

--- a/database/migrations/2025_08_26_000300_create_expenses_table.php
+++ b/database/migrations/2025_08_26_000300_create_expenses_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('expenses', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('description');
+            $table->decimal('total_amount', 10, 2);
+            $table->uuid('payer_id');
+            $table->uuid('group_id');
+            $table->string('ticket_image_url')->nullable();
+            $table->string('ocr_status')->nullable();
+            $table->text('ocr_raw_text')->nullable();
+            $table->string('status')->default('pending');
+            $table->date('expense_date');
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->useCurrent()->useCurrentOnUpdate();
+
+            $table->foreign('payer_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->foreign('group_id')->references('id')->on('groups')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('expenses');
+    }
+};

--- a/database/migrations/2025_08_26_000400_create_group_members_table.php
+++ b/database/migrations/2025_08_26_000400_create_group_members_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('group_members', function (Blueprint $table) {
+            $table->uuid('group_id');
+            $table->uuid('user_id');
+            $table->string('role')->default('member');
+            $table->timestamp('joined_at')->useCurrent();
+
+            $table->primary(['group_id', 'user_id']);
+            $table->foreign('group_id')->references('id')->on('groups')->cascadeOnDelete();
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('group_members');
+    }
+};

--- a/database/migrations/2025_08_26_000500_create_expense_participants_table.php
+++ b/database/migrations/2025_08_26_000500_create_expense_participants_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('expense_participants', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('expense_id');
+            $table->uuid('user_id');
+            $table->decimal('amount_due', 10, 2);
+            $table->boolean('is_paid')->default(false);
+            $table->uuid('payment_id')->nullable();
+
+            $table->foreign('expense_id')->references('id')->on('expenses')->cascadeOnDelete();
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->foreign('payment_id')->references('id')->on('payments')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('expense_participants');
+    }
+};


### PR DESCRIPTION
## Summary
- add users table with UUID primary key and profile fields
- add groups, payments, expenses, group_members and expense_participants tables with foreign keys

## Testing
- ⚠️ `php artisan test` (failed: require vendor/autoload.php)


------
https://chatgpt.com/codex/tasks/task_e_68add292ecdc83248d65937d2ad5a736