### PR TITLE
Add basic tests and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: sqlite
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-progress --prefer-dist
+      - name: Run tests
+        run: php artisan test

--- a/database/migrations/2025_08_20_000000_create_core_tables.php
+++ b/database/migrations/2025_08_20_000000_create_core_tables.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('profile_picture_url')->nullable();
+            $table->string('phone_number')->nullable();
+            $table->string('password_hash')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('expenses', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('description');
+            $table->decimal('total_amount', 10, 2);
+            $table->uuid('payer_id');
+            $table->uuid('group_id')->nullable();
+            $table->string('ticket_image_url')->nullable();
+            $table->string('ocr_status')->default('pending');
+            $table->string('ocr_raw_text')->nullable();
+            $table->string('status')->default('pending');
+            $table->date('expense_date');
+            $table->timestamps();
+        });
+
+        Schema::create('expense_participants', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('expense_id');
+            $table->uuid('user_id');
+            $table->decimal('amount_due', 10, 2);
+            $table->boolean('is_paid')->default(false);
+            $table->uuid('payment_id')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('payments', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('payer_id');
+            $table->uuid('receiver_id');
+            $table->decimal('amount', 10, 2);
+            $table->string('payment_method')->nullable();
+            $table->string('proof_url')->nullable();
+            $table->string('signature')->nullable();
+            $table->string('status');
+            $table->dateTime('payment_date')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payments');
+        Schema::dropIfExists('expense_participants');
+        Schema::dropIfExists('expenses');
+        Schema::dropIfExists('users');
+    }
+};

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/tests/Feature/ExpenseControllerTest.php
+++ b/tests/Feature/ExpenseControllerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use App\Models\User;
+
+class ExpenseControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_returns_empty_list(): void
+    {
+        $user = User::create([
+            'id' => (string) Str::uuid(),
+            'name' => 'Tester',
+            'email' => 'tester@example.com',
+        ]);
+
+        $this->actingAs($user, 'sanctum');
+
+        $response = $this->getJson('/api/expenses');
+
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'data' => [],
+                 ]);
+    }
+}

--- a/tests/Feature/PaymentControllerTest.php
+++ b/tests/Feature/PaymentControllerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use App\Models\User;
+
+class PaymentControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_returns_empty_list(): void
+    {
+        $user = User::create([
+            'id' => (string) Str::uuid(),
+            'name' => 'Tester',
+            'email' => 'tester@example.com',
+        ]);
+
+        $this->actingAs($user, 'sanctum');
+
+        $response = $this->getJson('/api/payments');
+
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'data' => [],
+                 ]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,5 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use CreatesApplication;
 }

--- a/tests/Unit/MoneyHelperTest.php
+++ b/tests/Unit/MoneyHelperTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Http\Controllers\Api\PaymentController;
+use ReflectionClass;
+
+class MoneyHelperTest extends TestCase
+{
+    public function test_money_formats_numbers(): void
+    {
+        $controller = new PaymentController();
+        $ref = new ReflectionClass($controller);
+        $method = $ref->getMethod('money');
+        $method->setAccessible(true);
+
+        $this->assertSame('10.50', $method->invoke($controller, 10.5));
+        $this->assertSame('0.00', $method->invoke($controller, null));
+    }
+}


### PR DESCRIPTION
## Summary
- add feature tests for expenses and payments with RefreshDatabase
- cover money formatting with unit test
- run tests in GitHub Actions

## Testing
- `composer install` *(fails: curl error 56 while downloading doctrine/inflector)*
- `php artisan test` *(fails: require vendor/autoload.php: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68add29354d08324ad5c55bc795e232d