### PR TITLE
Use eager loading for payment show

### DIFF
--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -14,8 +14,8 @@ class Payment extends Model
 
     protected $fillable = [
         'id',
-        'payer_id',
-        'receiver_id',
+        'from_user_id',
+        'to_user_id',
         'amount',
         'payment_method',
         'proof_url',
@@ -31,12 +31,12 @@ class Payment extends Model
 
     public function payer()
     {
-        return $this->belongsTo(User::class, 'payer_id');
+        return $this->belongsTo(User::class, 'from_user_id');
     }
 
     public function receiver()
     {
-        return $this->belongsTo(User::class, 'receiver_id');
+        return $this->belongsTo(User::class, 'to_user_id');
     }
 
     public function expenseParticipants()


### PR DESCRIPTION
## Summary
- eager load payer and receiver in payment show endpoint
- align Payment model relations with from/to user columns

## Testing
- `composer test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68ae655641988324b7d97d1428587939