### PR TITLE
Add comprehensive API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ contraseña correspondientes.
 | `npm run dev`              | Compila activos front‑end con Vite.              |
 | `php artisan test`         | Ejecuta la suite de pruebas.                     |
 
+## Documentación de la API
+
+La documentación completa de los endpoints se encuentra en [docs/API.md](docs/API.md).
+
 ## Endpoints principales
 
 Todos los endpoints se exponen bajo `/api` y requieren autenticación con


### PR DESCRIPTION
## Summary
- document all API endpoints in new `docs/API.md`
- link README to the full API documentation

## Testing
- `php artisan test` *(fails: Failed to open vendor/autoload.php)*
- `composer install` *(fails: GitHub API 403 when downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6936837883248fa3763737284fb7