### PR TITLE
Add tests for auth, groups, and payment flows

### DIFF
--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Group;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class GroupFactory extends Factory
+{
+    protected $model = Group::class;
+
+    public function definition(): array
+    {
+        return [
+            'id' => (string) Str::uuid(),
+            'name' => $this->faker->company(),
+            'description' => $this->faker->sentence(),
+            'owner_id' => \App\Models\User::factory(),
+            'created_at' => now(),
+        ];
+    }
+}

--- a/database/factories/InvitationFactory.php
+++ b/database/factories/InvitationFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Invitation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+use Carbon\Carbon;
+
+class InvitationFactory extends Factory
+{
+    protected $model = Invitation::class;
+
+    public function definition(): array
+    {
+        return [
+            'id' => (string) Str::uuid(),
+            'inviter_id' => \App\Models\User::factory(),
+            'invitee_email' => $this->faker->safeEmail(),
+            'group_id' => \App\Models\Group::factory(),
+            'token' => Str::random(40),
+            'status' => 'pending',
+            'expires_at' => Carbon::now()->addDays(7),
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,43 +2,26 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
-/**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
- */
 class UserFactory extends Factory
 {
-    /**
-     * The current password being used by the factory.
-     */
-    protected static ?string $password;
+    protected $model = User::class;
 
-    /**
-     * Define the model's default state.
-     *
-     * @return array<string, mixed>
-     */
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
-            'email' => fake()->unique()->safeEmail(),
-            'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
-            'remember_token' => Str::random(10),
+            'id' => (string) Str::uuid(),
+            'name' => $this->faker->name(),
+            'email' => $this->faker->unique()->safeEmail(),
+            'password_hash' => Hash::make('password'),
+            'profile_picture_url' => null,
+            'phone_number' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
         ];
-    }
-
-    /**
-     * Indicate that the model's email address should be unverified.
-     */
-    public function unverified(): static
-    {
-        return $this->state(fn (array $attributes) => [
-            'email_verified_at' => null,
-        ]);
     }
 }

--- a/tests/Feature/AuthControllerTest.php
+++ b/tests/Feature/AuthControllerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class AuthControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_register_with_invitation(): void
+    {
+        $owner = User::factory()->create();
+        $group = Group::factory()->create(['owner_id' => $owner->id]);
+
+        DB::table('group_members')->insert([
+            'id' => (string) Str::uuid(),
+            'group_id' => $group->id,
+            'user_id' => $owner->id,
+            'role' => 'owner',
+            'joined_at' => now(),
+        ]);
+
+        $inviteEmail = 'invitee@example.com';
+        $this->actingAs($owner, 'sanctum');
+        $invResponse = $this->postJson('/api/invitations', [
+            'invitee_email' => $inviteEmail,
+            'group_id' => $group->id,
+        ])->assertStatus(201);
+
+        $token = $invResponse->json('invitation.token');
+
+        $registerResponse = $this->postJson('/api/auth/register', [
+            'name' => 'Invited User',
+            'email' => $inviteEmail,
+            'password' => 'secret123',
+            'password_confirmation' => 'secret123',
+            'invitation_token' => $token,
+        ]);
+
+        $registerResponse->assertStatus(201)
+            ->assertJsonStructure([
+                'message',
+                'token',
+                'user' => ['id', 'name', 'email'],
+            ]);
+
+        $user = User::where('email', $inviteEmail)->first();
+
+        $this->assertDatabaseHas('group_members', [
+            'group_id' => $group->id,
+            'user_id' => $user->id,
+        ]);
+
+        $this->assertDatabaseHas('invitations', [
+            'token' => $token,
+            'status' => 'accepted',
+        ]);
+    }
+
+    public function test_user_can_login_with_valid_credentials(): void
+    {
+        $password = 'secret123';
+        $user = User::factory()->create([
+            'password_hash' => Hash::make($password),
+        ]);
+
+        $response = $this->postJson('/api/auth/login', [
+            'email' => $user->email,
+            'password' => $password,
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'message',
+                'token',
+                'user' => ['id', 'name', 'email'],
+            ]);
+    }
+}

--- a/tests/Feature/GroupControllerTest.php
+++ b/tests/Feature/GroupControllerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class GroupControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_create_group(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user, 'sanctum');
+
+        $response = $this->postJson('/api/groups', [
+            'name' => 'Mi Grupo',
+            'description' => 'Descripcion',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJson([
+                'message' => 'Grupo creado',
+                'group' => [
+                    'name' => 'Mi Grupo',
+                    'description' => 'Descripcion',
+                    'owner_id' => $user->id,
+                ],
+            ]);
+    }
+
+    public function test_owner_can_update_group(): void
+    {
+        $user = User::factory()->create();
+        $group = Group::factory()->create(['owner_id' => $user->id]);
+        DB::table('group_members')->insert([
+            'id' => (string) Str::uuid(),
+            'group_id' => $group->id,
+            'user_id' => $user->id,
+            'role' => 'owner',
+            'joined_at' => now(),
+        ]);
+
+        $this->actingAs($user, 'sanctum');
+
+        $response = $this->putJson('/api/groups/' . $group->id, [
+            'description' => 'Actualizado',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'Grupo actualizado',
+                'group' => [
+                    'id' => $group->id,
+                    'description' => 'Actualizado',
+                ],
+            ]);
+    }
+}

--- a/tests/Feature/InvitationExpensePaymentFlowTest.php
+++ b/tests/Feature/InvitationExpensePaymentFlowTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class InvitationExpensePaymentFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_full_flow_invitation_expense_payment_approval_and_rejection(): void
+    {
+        $owner = User::factory()->create();
+        $group = Group::factory()->create(['owner_id' => $owner->id]);
+        DB::table('group_members')->insert([
+            'id' => (string) Str::uuid(),
+            'group_id' => $group->id,
+            'user_id' => $owner->id,
+            'role' => 'owner',
+            'joined_at' => now(),
+        ]);
+
+        // Invite new member
+        $inviteEmail = 'flowuser@example.com';
+        $this->actingAs($owner, 'sanctum');
+        $inv = $this->postJson('/api/invitations', [
+            'invitee_email' => $inviteEmail,
+            'group_id' => $group->id,
+        ])->assertStatus(201);
+        $token = $inv->json('invitation.token');
+
+        // Register invited user
+        $this->postJson('/api/auth/register', [
+            'name' => 'Flow User',
+            'email' => $inviteEmail,
+            'password' => 'secret123',
+            'password_confirmation' => 'secret123',
+            'invitation_token' => $token,
+        ])->assertStatus(201);
+        $member = User::where('email', $inviteEmail)->first();
+
+        // Owner creates expense
+        $this->actingAs($owner, 'sanctum');
+        $expense = $this->postJson('/api/expenses', [
+            'description' => 'Cena',
+            'total_amount' => 100,
+            'group_id' => $group->id,
+            'expense_date' => now()->toDateString(),
+            'has_ticket' => false,
+            'participants' => [
+                ['user_id' => $member->id, 'amount_due' => 100],
+            ],
+        ])->assertStatus(201);
+        $expenseId = $expense->json('expense.id');
+
+        // Participant creates payment
+        $this->actingAs($member, 'sanctum');
+        $payment = $this->postJson('/api/payments', [
+            'group_id' => $group->id,
+            'from_user_id' => $member->id,
+            'to_user_id' => $owner->id,
+            'amount' => 100,
+        ])->assertStatus(201);
+        $paymentId = $payment->json('payment.id');
+
+        // Owner approves payment
+        $this->actingAs($owner, 'sanctum');
+        $this->postJson("/api/payments/{$paymentId}/approve")
+            ->assertStatus(200)
+            ->assertJsonPath('payment.status', 'approved');
+
+        $this->assertDatabaseHas('expense_participants', [
+            'expense_id' => $expenseId,
+            'user_id' => $member->id,
+            'is_paid' => true,
+        ]);
+
+        // Another payment to reject
+        $this->actingAs($member, 'sanctum');
+        $payment2 = $this->postJson('/api/payments', [
+            'group_id' => $group->id,
+            'from_user_id' => $member->id,
+            'to_user_id' => $owner->id,
+            'amount' => 50,
+        ])->assertStatus(201);
+        $payment2Id = $payment2->json('payment.id');
+
+        $this->actingAs($owner, 'sanctum');
+        $this->postJson("/api/payments/{$payment2Id}/reject")
+            ->assertStatus(200)
+            ->assertJsonPath('message', 'Payment rejected');
+
+        $this->assertDatabaseHas('payments', [
+            'id' => $payment2Id,
+            'status' => 'rejected',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add factories for users, groups, and invitations
- test registration and login via AuthController
- test group creation and update
- cover invitation, expense, and payment approval/rejection flow

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7243864c83249672738d4f49722a