### PR TITLE
docs: add push notification configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,36 @@ El proyecto está pensado para PostgreSQL. Ajusta las variables anteriores segú
 | `npm run dev`              | Compila activos front‑end con Vite.              |
 | `php artisan test`         | Ejecuta la suite de pruebas.                     |
 
+## Notificaciones Push
+
+Para enviar notificaciones push se utilizan Firebase Cloud Messaging (FCM) y Apple Push Notification service (APNs).
+
+Variables de entorno:
+
+| Variable          | Descripción                                  |
+|-------------------|----------------------------------------------|
+| `FCM_SERVER_KEY`  | Clave del servidor para FCM.                 |
+| `APN_AUTH_TOKEN`  | Token de autenticación de APNs.              |
+| `APN_TOPIC`       | Identificador del tópico de la app en APNs.  |
+
+Ejemplo en el `.env`:
+
+```env
+FCM_SERVER_KEY=tu_clave_fcm
+APN_AUTH_TOKEN=tu_token_apn
+APN_TOPIC=com.example.app
+```
+
+Para procesar el job `SendPushNotification` es necesario ejecutar el trabajador de la cola:
+
+```bash
+php artisan queue:work
+```
+
+Documentación adicional:
+- [Firebase Cloud Messaging](https://firebase.google.com/docs/cloud-messaging)
+- [Apple Push Notification service](https://developer.apple.com/documentation/usernotifications)
+
 ## Datos de prueba
 
 Para generar datos iniciales, incluyendo un grupo de ejemplo y una invitación,


### PR DESCRIPTION
## Summary
- document FCM/APNs env vars
- mention queue worker for `SendPushNotification`

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: curl error 56 while downloading https://api.github.com/... CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ae84bf49788324a445d86d8b192847