### PR TITLE
feat: add recurring payments endpoint

### DIFF
--- a/app/Http/Controllers/Api/RecurringPaymentController.php
+++ b/app/Http/Controllers/Api/RecurringPaymentController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
+
+class RecurringPaymentController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $userId = $request->user()->id;
+
+        $items = DB::table('recurring_payments as rp')
+            ->leftJoin('recurring_payment_viewers as rpv', 'rpv.recurring_payment_id', '=', 'rp.id')
+            ->where(function ($q) use ($userId) {
+                $q->where('rp.user_id', $userId)
+                  ->orWhere('rpv.user_id', $userId);
+            })
+            ->select('rp.*')
+            ->distinct()
+            ->get();
+
+        return response()->json($items, 200);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $userId = $request->user()->id;
+
+        $data = $request->validate([
+            'description'    => ['required', 'string'],
+            'amount_monthly' => ['required', 'numeric', 'gt:0'],
+            'months'         => ['required', 'integer', 'min:1'],
+            'shared_with'    => ['sometimes', 'array'],
+            'shared_with.*'  => ['uuid', 'exists:users,id'],
+        ]);
+
+        $id = (string) Str::uuid();
+
+        DB::transaction(function () use ($data, $id, $userId) {
+            DB::table('recurring_payments')->insert([
+                'id'             => $id,
+                'user_id'        => $userId,
+                'description'    => $data['description'],
+                'amount_monthly' => $data['amount_monthly'],
+                'months'         => $data['months'],
+                'created_at'     => now(),
+                'updated_at'     => now(),
+            ]);
+
+            if (!empty($data['shared_with'])) {
+                $rows = collect($data['shared_with'])->map(fn ($uid) => [
+                    'recurring_payment_id' => $id,
+                    'user_id'              => $uid,
+                ])->all();
+                DB::table('recurring_payment_viewers')->insert($rows);
+            }
+        });
+
+        $item = DB::table('recurring_payments')->where('id', $id)->first();
+
+        return response()->json(['message' => 'Recurring payment created', 'data' => $item], 201);
+    }
+}

--- a/app/Models/RecurringPayment.php
+++ b/app/Models/RecurringPayment.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class RecurringPayment extends Model
+{
+    use HasFactory;
+
+    protected $table = 'recurring_payments';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'id',
+        'user_id',
+        'description',
+        'amount_monthly',
+        'months',
+    ];
+
+    protected $casts = [
+        'amount_monthly' => 'decimal:2',
+    ];
+
+    public function owner()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function viewers()
+    {
+        return $this->belongsToMany(User::class, 'recurring_payment_viewers');
+    }
+}

--- a/database/migrations/2025_08_28_000000_create_recurring_payments_table.php
+++ b/database/migrations/2025_08_28_000000_create_recurring_payments_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('recurring_payments', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('user_id');
+            $table->string('description');
+            $table->decimal('amount_monthly', 10, 2);
+            $table->unsignedInteger('months');
+            $table->timestampsTz();
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+
+        Schema::create('recurring_payment_viewers', function (Blueprint $table) {
+            $table->uuid('recurring_payment_id');
+            $table->uuid('user_id');
+            $table->primary(['recurring_payment_id', 'user_id']);
+            $table->foreign('recurring_payment_id')->references('id')->on('recurring_payments')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('recurring_payment_viewers');
+        Schema::dropIfExists('recurring_payments');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Api\BalanceController;
 use App\Http\Controllers\Api\NotificationController;
 use App\Http\Controllers\Api\DashboardController;
 use App\Http\Controllers\Api\ReportController;
+use App\Http\Controllers\Api\RecurringPaymentController;
 
 /**
  * RUTAS PÚBLICAS (sin auth)
@@ -66,6 +67,9 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::apiResource('payments', PaymentController::class)->only(['index','store','show','update']);
     Route::post('payments/{payment}/approve', [PaymentController::class, 'approve']);
     Route::post('payments/{payment}/reject', [PaymentController::class, 'reject']);
+
+    // Pagos recurrentes
+    Route::apiResource('recurring-payments', RecurringPaymentController::class)->only(['index','store']);
 
 
     // Notificaciones

--- a/tests/Feature/RecurringPaymentControllerTest.php
+++ b/tests/Feature/RecurringPaymentControllerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use App\Models\User;
+
+class RecurringPaymentControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_create_and_share_recurring_payment(): void
+    {
+        $owner = User::create([
+            'id' => (string) Str::uuid(),
+            'name' => 'Owner',
+            'email' => 'owner@example.com',
+        ]);
+
+        $viewer = User::create([
+            'id' => (string) Str::uuid(),
+            'name' => 'Viewer',
+            'email' => 'viewer@example.com',
+        ]);
+
+        $this->actingAs($owner, 'sanctum');
+
+        $payload = [
+            'description' => 'Pago tarjeta',
+            'amount_monthly' => 100.50,
+            'months' => 12,
+            'shared_with' => [$viewer->id],
+        ];
+
+        $resp = $this->postJson('/api/recurring-payments', $payload);
+        $resp->assertStatus(201)->assertJsonPath('data.description', 'Pago tarjeta');
+
+        // Owner can list it
+        $listOwner = $this->getJson('/api/recurring-payments');
+        $listOwner->assertStatus(200)->assertJsonFragment(['description' => 'Pago tarjeta']);
+
+        // Viewer can also list it
+        $this->actingAs($viewer, 'sanctum');
+        $listViewer = $this->getJson('/api/recurring-payments');
+        $listViewer->assertStatus(200)->assertJsonFragment(['description' => 'Pago tarjeta']);
+    }
+}


### PR DESCRIPTION
## Summary
- add recurring payment model, controller, migration, and API routes
- create tests for creating and sharing recurring payments

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ba28a7448324b9ad8e7179f33a90