### PR TITLE
docs: add group registration workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,13 @@ Laravel Sanctum salvo donde se indique.
 
 ## Flujos de trabajo
 
+### Registro y creación de grupos
+1. Solicitar o recibir un token de invitación.
+2. Registrar al usuario con `POST /api/auth/register`.
+3. Crear un grupo con `POST /api/groups`.
+4. Generar invitaciones con `POST /api/invitations` y enviar los token(s) resultantes.
+5. Si la persona invitada aún no está registrada, se le debe proporcionar también un token de registro.
+
 ### Invitaciones
 1. Un propietario o administrador del grupo crea una invitación.
 2. El invitado verifica el token (`GET /api/invitations/token/{token}`).


### PR DESCRIPTION
## Summary
- document how to register a user and create groups with invitation tokens

## Testing
- `php artisan test` *(fails: vendor/autoload.php not found)*
- `composer install --no-interaction --no-progress` *(fails: unable to clone packages from GitHub, CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5091e014083249f2425e7ae4bf4dc