### PR TITLE
feat: add registration token flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,14 +134,16 @@ ejecutar:
 php artisan migrate --seed --class=DevSeeder
 ```
 
-La consola mostrará un token de invitación, por ejemplo:
+La consola mostrará un token de registro y uno de invitación, por ejemplo:
 
 ```
+Token de registro para newuser@example.com:
+REGTOKEN123...
 Token de invitación para newuser@example.com:
-4f3b59d2c4e148d9a5b2bdf5b6c177a3e0b8b50d71675dc1a1e4b42e2c596ef8
+INVTOKEN456...
 ```
 
-Con este token se puede registrar un usuario con el endpoint:
+Con estos tokens se puede registrar un usuario con el endpoint:
 
 ```http
 POST /api/auth/register
@@ -150,7 +152,8 @@ POST /api/auth/register
   "email": "newuser@example.com",
   "password": "secret1234",
   "password_confirmation": "secret1234",
-  "invitation_token": "4f3b59d2c4e148d9a5b2bdf5b6c177a3e0b8b50d71675dc1a1e4b42e2c596ef8"
+  "registration_token": "REGTOKEN123...",
+  "invitation_token": "INVTOKEN456..."
 }
 ```
 

--- a/app/Models/RegistrationToken.php
+++ b/app/Models/RegistrationToken.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class RegistrationToken extends Model
+{
+    public $timestamps = true;
+    public $incrementing = false;
+    protected $keyType = 'string';
+    protected $table = 'registration_tokens';
+
+    protected $fillable = [
+        'email',
+        'token',
+        'expires_at',
+        'status',
+    ];
+
+    protected $casts = [
+        'expires_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+}

--- a/database/migrations/2025_08_29_000000_create_registration_tokens_table.php
+++ b/database/migrations/2025_08_29_000000_create_registration_tokens_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('registration_tokens', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('email');
+            $table->string('token', 64)->unique();
+            $table->dateTimeTz('expires_at')->nullable();
+            $table->string('status', 20)->default('pending');
+            $table->timestampsTz();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('registration_tokens');
+    }
+};

--- a/database/seeders/DevSeeder.php
+++ b/database/seeders/DevSeeder.php
@@ -45,11 +45,22 @@ class DevSeeder extends Seeder
             'inviter_id'    => $ownerId,
             'invitee_email' => 'newuser@example.com',
             'group_id'      => $groupId,
-            'token'         => $token = Str::random(64),
+            'token'         => $invToken = Str::random(64),
             'status'        => 'pending',
             'expires_at'    => now()->addDays(7),
         ]);
 
-        echo "\nToken de invitación para newuser@example.com:\n$token\n\n";
+        DB::table('registration_tokens')->insert([
+            'id'         => (string) Str::uuid(),
+            'email'      => 'newuser@example.com',
+            'token'      => $regToken = Str::random(64),
+            'status'     => 'pending',
+            'expires_at' => now()->addDays(7),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        echo "\nToken de registro para newuser@example.com:\n$regToken\n";
+        echo "Token de invitación para newuser@example.com:\n$invToken\n\n";
     }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -18,9 +18,9 @@ Todas las rutas están bajo el prefijo `/api`. A menos que se indique lo contrar
 
    El endpoint devuelve un token de invitación (`token`) que se enviará al invitado.
 
-2. **Registrar un usuario con el token**
+2. **Registrar un usuario con los tokens**
 
-   El invitado usa el token recibido para registrarse vía `POST /api/auth/register`.
+   El invitado usa el `registration_token` recibido y opcionalmente el `group_token` para registrarse vía `POST /api/auth/register`.
 
    ```http
    POST /api/auth/register
@@ -29,7 +29,8 @@ Todas las rutas están bajo el prefijo `/api`. A menos que se indique lo contrar
      "email": "nuevo@correo.com",
      "password": "secreto",
      "password_confirmation": "secreto",
-     "invitation_token": "TOKEN"
+     "registration_token": "REGTOKEN",
+     "invitation_token": "GROUPTOKEN" // opcional
    }
    ```
 
@@ -51,21 +52,22 @@ Todas las rutas están bajo el prefijo `/api`. A menos que se indique lo contrar
    Si el correo no está asociado a un usuario, la invitación genera **dos** tokens:
 
    - `registration_token`: para crear la cuenta mediante `POST /api/auth/register`.
-   - `group_token`: para unirse al grupo después del registro mediante `POST /api/invitations/accept`.
+   - `group_token` (`invitation_token`): para unirse al grupo después del registro mediante `POST /api/invitations/accept`.
 
    El cliente debe manejar ambos tokens en el flujo de alta de usuario.
 
 ## Autenticación
 
 ### POST /api/auth/register
-Registra un usuario a partir de una invitación.
+Registra un usuario utilizando un token de registro.
 
 **Body**
 - `name` (string, requerido)
 - `email` (string, requerido)
 - `password` (string, min 8, requerido)
 - `password_confirmation` (string, debe coincidir)
-- `invitation_token` (string, requerido)
+- `registration_token` (string, requerido)
+- `invitation_token` (string, opcional)
 - `profile_picture_url` (url, opcional)
 - `phone_number` (string, opcional)
 

--- a/docs/api.http
+++ b/docs/api.http
@@ -10,6 +10,7 @@ Content-Type: application/json
   "email": "juan@example.com",
   "password": "secret123",
   "password_confirmation": "secret123",
+  "registration_token": "REG123",
   "invitation_token": "ABC123"
 }
 

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -24,7 +24,7 @@ paths:
           application/json:
             schema:
               type: object
-              required: [name, email, password, password_confirmation, invitation_token]
+              required: [name, email, password, password_confirmation, registration_token]
               properties:
                 name:
                   type: string
@@ -37,6 +37,8 @@ paths:
                 password_confirmation:
                   type: string
                   format: password
+                registration_token:
+                  type: string
                 invitation_token:
                   type: string
                 profile_picture_url:
@@ -49,6 +51,7 @@ paths:
               email: juan@example.com
               password: secret123
               password_confirmation: secret123
+              registration_token: REG123
               invitation_token: ABC123
       responses:
         '201':

--- a/tests/Feature/AuthControllerTest.php
+++ b/tests/Feature/AuthControllerTest.php
@@ -34,13 +34,15 @@ class AuthControllerTest extends TestCase
             'group_id' => $group->id,
         ])->assertStatus(201);
 
-        $token = $invResponse->json('invitation.token');
+        $token     = $invResponse->json('invitation.token');
+        $regToken  = $invResponse->json('registration_token.token');
 
         $registerResponse = $this->postJson('/api/auth/register', [
             'name' => 'Invited User',
             'email' => $inviteEmail,
             'password' => 'secret123',
             'password_confirmation' => 'secret123',
+            'registration_token' => $regToken,
             'invitation_token' => $token,
         ]);
 

--- a/tests/Feature/InvitationExpensePaymentFlowTest.php
+++ b/tests/Feature/InvitationExpensePaymentFlowTest.php
@@ -32,7 +32,8 @@ class InvitationExpensePaymentFlowTest extends TestCase
             'invitee_email' => $inviteEmail,
             'group_id' => $group->id,
         ])->assertStatus(201);
-        $token = $inv->json('invitation.token');
+        $token    = $inv->json('invitation.token');
+        $regToken = $inv->json('registration_token.token');
 
         // Register invited user
         $this->postJson('/api/auth/register', [
@@ -40,6 +41,7 @@ class InvitationExpensePaymentFlowTest extends TestCase
             'email' => $inviteEmail,
             'password' => 'secret123',
             'password_confirmation' => 'secret123',
+            'registration_token' => $regToken,
             'invitation_token' => $token,
         ])->assertStatus(201);
         $member = User::where('email', $inviteEmail)->first();


### PR DESCRIPTION
## Summary
- add migration/model for registration tokens
- require registration_token on register and handle optional invitation_token
- issue registration tokens when inviting unknown emails
- document two-token registration flow

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b50ced386c83249210889d2e9a6725