### PR TITLE
Add payment method field to payments API

### DIFF
--- a/app/Http/Controllers/Api/PaymentController.php
+++ b/app/Http/Controllers/Api/PaymentController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 use Carbon\Carbon;
 use App\Models\Payment;
 use App\Jobs\SendPushNotification;
+use Illuminate\Validation\Rule;
 
 class PaymentController extends Controller
 {
@@ -74,6 +75,7 @@ class PaymentController extends Controller
             'amount'       => ['required', 'numeric', 'gt:0'],
             'note'         => ['sometimes', 'nullable', 'string'],
             'evidence_url' => ['sometimes', 'nullable', 'url'],
+            'payment_method' => ['sometimes', 'nullable', 'string', Rule::in(['cash', 'transfer'])],
         ]);
 
         if ($data['from_user_id'] !== $userId) {
@@ -97,6 +99,7 @@ class PaymentController extends Controller
             'amount' => $data['amount'],
             'note' => $data['note'] ?? null,
             'evidence_url' => $data['evidence_url'] ?? null,
+            'payment_method' => $data['payment_method'] ?? null,
             'status' => 'pending',
             'created_at' => now(),
             'updated_at' => now(),
@@ -169,7 +172,7 @@ class PaymentController extends Controller
         if ($p->status !== 'pending') return response()->json(['message' => 'Solo puedes actualizar pagos pendientes'], 409);
 
         $data = $request->validate([
-            'payment_method' => ['sometimes', 'nullable', 'string', 'max:100'],
+            'payment_method' => ['sometimes', 'nullable', 'string', Rule::in(['cash', 'transfer'])],
             'proof_url'      => ['sometimes', 'nullable', 'url'],
             'signature'      => ['sometimes', 'nullable', 'string'],
         ]);
@@ -375,6 +378,7 @@ class PaymentController extends Controller
             'amount'        => $this->money($p->amount),
             'status'        => $p->status,
             'payment_date'  => $p->payment_date,
+            'payment_method' => $p->payment_method,
             'note'          => $p->note,
             'evidence_url'  => $p->evidence_url,
             'from_user_id'  => $p->from_user_id,

--- a/docs/API.md
+++ b/docs/API.md
@@ -220,12 +220,18 @@ Crea un pago entre dos miembros de un grupo.
 - `amount` (number, requerido)
 - `note` (string, opcional)
 - `evidence_url` (url, opcional)
+- `payment_method` (`cash`|`transfer`, opcional)
 
 ### GET /api/payments/{id}
 Muestra detalles de un pago.
 
 ### PUT /api/payments/{id}
 Actualiza un pago pendiente.
+
+**Body** (al menos un campo)
+- `payment_method` (`cash`|`transfer`, opcional)
+- `proof_url` (url, opcional)
+- `signature` (string, opcional)
 
 ### POST /api/payments/{id}/approve
 El receptor aprueba el pago y aplica el monto a deudas.


### PR DESCRIPTION
## Summary
- validate and store `payment_method` when creating or updating payments
- expose `payment_method` in payment responses
- document allowed `payment_method` values (`cash`, `transfer`)

## Testing
- `composer test` *(fails: require(/workspace/gestion-financiera/vendor/autoload.php): Failed to open stream)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b50cf62b5883248e349ce675e1f61b