### PR TITLE
feat: deactivate users instead of deleting

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -141,6 +141,10 @@ class AuthController extends Controller
             return response()->json(['message' => 'Credenciales inválidas'], 401);
         }
 
+        if (! $user->is_active) {
+            return response()->json(['message' => 'Cuenta desactivada'], 403);
+        }
+
         $deviceName = $request->header('X-Device-Name', 'api');
         $token = $user->createToken($deviceName)->plainTextToken;
 

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -103,11 +103,12 @@ class UserController extends Controller
         $user = $request->user();
 
         DB::transaction(function () use ($user) {
-            // Revocar todos los tokens antes de borrar
+            // Revocar todos los tokens
             $user->tokens()->delete();
 
-            // Eliminar usuario (tu BD maneja cascadas y set null según diseño)
-            $user->delete();
+            // Desactivar usuario
+            $user->is_active = false;
+            $user->save();
         });
 
         // 204 No Content: sin cuerpo de respuesta

--- a/app/Http/Middleware/EnsureUserIsActive.php
+++ b/app/Http/Middleware/EnsureUserIsActive.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureUserIsActive
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if ($user && ! $user->is_active) {
+            return response()->json(['message' => 'Cuenta desactivada'], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -33,6 +33,7 @@ class User extends Authenticatable
     protected $casts = [
         'id' => 'string',
         'email_verified_at' => 'datetime',
+        'is_active' => 'boolean',
     ];
 
     public function groups()

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -14,6 +14,10 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware) {
         // No redirigir invitados (devolver 401 JSON en APIs)
         $middleware->redirectGuestsTo(fn() => null);
+
+        $middleware->alias([
+            'active' => \App\Http\Middleware\EnsureUserIsActive::class,
+        ]);
     })
 
     ->withExceptions(function (Exceptions $exceptions) {

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -20,6 +20,7 @@ class UserFactory extends Factory
             'password_hash' => Hash::make('password'),
             'profile_picture_url' => null,
             'phone_number' => null,
+            'is_active' => true,
             'created_at' => now(),
             'updated_at' => now(),
         ];

--- a/database/migrations/2025_08_29_000000_add_is_active_to_users_table.php
+++ b/database/migrations/2025_08_29_000000_add_is_active_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_active')->default(true);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_active');
+        });
+    }
+};

--- a/docs/API.md
+++ b/docs/API.md
@@ -70,7 +70,7 @@ Registra un usuario a partir de una invitación.
 - `phone_number` (string, opcional)
 
 ### POST /api/auth/login
-Inicia sesión y devuelve un token Sanctum.
+Inicia sesión y devuelve un token Sanctum. Usuarios desactivados no pueden iniciar sesión.
 
 **Body**
 - `email` (string, requerido)
@@ -101,7 +101,9 @@ Actualiza la contraseña del usuario.
 - `password` (string, min 8, confirmado)
 
 ### DELETE /api/users/me
-Elimina la cuenta del usuario y revoca sus tokens.
+Desactiva la cuenta del usuario y revoca sus tokens.
+El usuario no podrá iniciar sesión mientras esté inactivo.
+Actualmente no hay un endpoint para reactivar la cuenta; contacta al soporte si necesitas reactivarla.
 
 ## Grupos
 

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -77,6 +77,10 @@ paths:
       responses:
         '200':
           description: Token generado
+        '401':
+          description: Credenciales inválidas
+        '403':
+          description: Cuenta desactivada
   /auth/logout:
     post:
       summary: Cierra la sesión actual
@@ -121,10 +125,10 @@ paths:
         '200':
           description: Perfil actualizado
     delete:
-      summary: Elimina la cuenta del usuario y revoca sus tokens
+      summary: Desactiva la cuenta del usuario y revoca sus tokens
       responses:
         '204':
-          description: Cuenta eliminada
+          description: Cuenta desactivada
   /users/me/password:
     put:
       summary: Actualiza la contraseña del usuario

--- a/routes/api.php
+++ b/routes/api.php
@@ -31,7 +31,7 @@ Route::prefix('auth')->group(function () {
 /**
  * RUTAS PROTEGIDAS (con auth)
  */
-Route::middleware('auth:sanctum')->group(function () {
+Route::middleware(['auth:sanctum', 'active'])->group(function () {
 
     // Auth
     Route::post('/auth/logout', [AuthController::class, 'logout']);

--- a/tests/Feature/AuthControllerTest.php
+++ b/tests/Feature/AuthControllerTest.php
@@ -83,4 +83,23 @@ class AuthControllerTest extends TestCase
                 'user' => ['id', 'name', 'email'],
             ]);
     }
+
+    public function test_inactive_user_cannot_login(): void
+    {
+        $password = 'secret123';
+        $user = User::factory()->create([
+            'password_hash' => Hash::make($password),
+            'is_active' => false,
+        ]);
+
+        $response = $this->postJson('/api/auth/login', [
+            'email' => $user->email,
+            'password' => $password,
+        ]);
+
+        $response->assertStatus(403)
+            ->assertJson([
+                'message' => 'Cuenta desactivada',
+            ]);
+    }
 }

--- a/tests/Feature/UserControllerTest.php
+++ b/tests/Feature/UserControllerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class UserControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_deactivate_account(): void
+    {
+        $password = 'secret123';
+        $user = User::factory()->create([
+            'password_hash' => Hash::make($password),
+        ]);
+
+        $token = $user->createToken('api')->plainTextToken;
+
+        $response = $this->withToken($token)->deleteJson('/api/users/me');
+        $response->assertNoContent();
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'is_active' => false,
+        ]);
+
+        $this->withToken($token)->getJson('/api/users/me')->assertStatus(401);
+    }
+}


### PR DESCRIPTION
## Summary
- add `is_active` flag to users and migration
- deactivate account and revoke tokens instead of deleting
- block login and API access for inactive users
- document deactivation behavior

## Testing
- `composer test` *(fails: Failed to open stream: No such file or directory; composer install requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68b50d106ce88324af4db45ab661b7ef