### PR TITLE
feat: add recurring payment reminders

### DIFF
--- a/app/Console/Commands/SendRecurringPaymentReminders.php
+++ b/app/Console/Commands/SendRecurringPaymentReminders.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\RecurringPayment;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+
+class SendRecurringPaymentReminders extends Command
+{
+    protected $signature = 'recurring-payments:send-reminders';
+
+    protected $description = 'Send reminders for upcoming recurring payments';
+
+    public function handle(): int
+    {
+        $today = Carbon::today();
+
+        RecurringPayment::query()
+            ->chunk(100, function ($payments) use ($today) {
+                foreach ($payments as $payment) {
+                    $next = Carbon::parse($payment->start_date)->setDay($payment->day_of_month);
+
+                    while ($next->lt($today)) {
+                        $next->addMonthNoOverflow()->setDay($payment->day_of_month);
+                    }
+
+                    if ($today->diffInDays($next) == $payment->reminder_days_before) {
+                        $message = "Reminder for payment {$payment->title} to user {$payment->user_id}";
+                        $this->info($message);
+                        Log::info($message);
+                    }
+                }
+            });
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    protected function schedule(Schedule $schedule): void
+    {
+        //
+    }
+
+    protected function commands(): void
+    {
+        $this->load(__DIR__.'/Commands');
+    }
+}

--- a/app/Http/Controllers/Api/RecurringPaymentController.php
+++ b/app/Http/Controllers/Api/RecurringPaymentController.php
@@ -32,11 +32,15 @@ class RecurringPaymentController extends Controller
         $userId = $request->user()->id;
 
         $data = $request->validate([
-            'description'    => ['required', 'string'],
-            'amount_monthly' => ['required', 'numeric', 'gt:0'],
-            'months'         => ['required', 'integer', 'min:1'],
-            'shared_with'    => ['sometimes', 'array'],
-            'shared_with.*'  => ['uuid', 'exists:users,id'],
+            'title'               => ['required', 'string'],
+            'description'         => ['required', 'string'],
+            'amount_monthly'      => ['required', 'numeric', 'gt:0'],
+            'months'              => ['required', 'integer', 'min:1'],
+            'start_date'          => ['required', 'date'],
+            'day_of_month'        => ['required', 'integer', 'between:1,31'],
+            'reminder_days_before'=> ['required', 'integer', 'min:0'],
+            'shared_with'         => ['sometimes', 'array'],
+            'shared_with.*'       => ['uuid', 'exists:users,id'],
         ]);
 
         $id = (string) Str::uuid();
@@ -44,12 +48,16 @@ class RecurringPaymentController extends Controller
         DB::transaction(function () use ($data, $id, $userId) {
             DB::table('recurring_payments')->insert([
                 'id'             => $id,
-                'user_id'        => $userId,
-                'description'    => $data['description'],
-                'amount_monthly' => $data['amount_monthly'],
-                'months'         => $data['months'],
-                'created_at'     => now(),
-                'updated_at'     => now(),
+                'user_id'             => $userId,
+                'title'               => $data['title'],
+                'description'         => $data['description'],
+                'amount_monthly'      => $data['amount_monthly'],
+                'months'              => $data['months'],
+                'start_date'          => $data['start_date'],
+                'day_of_month'        => $data['day_of_month'],
+                'reminder_days_before'=> $data['reminder_days_before'],
+                'created_at'          => now(),
+                'updated_at'          => now(),
             ]);
 
             if (!empty($data['shared_with'])) {

--- a/app/Models/RecurringPayment.php
+++ b/app/Models/RecurringPayment.php
@@ -16,13 +16,18 @@ class RecurringPayment extends Model
     protected $fillable = [
         'id',
         'user_id',
+        'title',
         'description',
         'amount_monthly',
         'months',
+        'start_date',
+        'day_of_month',
+        'reminder_days_before',
     ];
 
     protected $casts = [
         'amount_monthly' => 'decimal:2',
+        'start_date' => 'date',
     ];
 
     public function owner()

--- a/database/migrations/2025_08_28_000000_create_recurring_payments_table.php
+++ b/database/migrations/2025_08_28_000000_create_recurring_payments_table.php
@@ -11,9 +11,13 @@ return new class extends Migration
         Schema::create('recurring_payments', function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->uuid('user_id');
+            $table->string('title');
             $table->string('description');
             $table->decimal('amount_monthly', 10, 2);
             $table->unsignedInteger('months');
+            $table->date('start_date');
+            $table->unsignedTinyInteger('day_of_month');
+            $table->unsignedInteger('reminder_days_before');
             $table->timestampsTz();
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });

--- a/docs/API.md
+++ b/docs/API.md
@@ -242,9 +242,13 @@ Lista pagos recurrentes creados por el usuario o compartidos con él.
 Crea un nuevo pago recurrente para recordar deudas periódicas.
 
 **Body**
+- `title` (string, requerido)
 - `description` (string, requerido)
 - `amount_monthly` (number, requerido, monto a pagar cada mes)
 - `months` (integer, requerido, duración en meses)
+- `start_date` (date, requerido, fecha del primer pago)
+- `day_of_month` (integer 1-31, requerido, día del mes para el cobro)
+- `reminder_days_before` (integer, requerido, días de anticipación para recordar)
 - `shared_with` (array de UUID, opcional, usuarios invitados como lectores)
 
 ## Notificaciones

--- a/tests/Feature/RecurringPaymentControllerTest.php
+++ b/tests/Feature/RecurringPaymentControllerTest.php
@@ -28,14 +28,18 @@ class RecurringPaymentControllerTest extends TestCase
         $this->actingAs($owner, 'sanctum');
 
         $payload = [
+            'title' => 'Pago tarjeta',
             'description' => 'Pago tarjeta',
             'amount_monthly' => 100.50,
             'months' => 12,
+            'start_date' => '2025-01-01',
+            'day_of_month' => 1,
+            'reminder_days_before' => 3,
             'shared_with' => [$viewer->id],
         ];
 
         $resp = $this->postJson('/api/recurring-payments', $payload);
-        $resp->assertStatus(201)->assertJsonPath('data.description', 'Pago tarjeta');
+        $resp->assertStatus(201)->assertJsonPath('data.title', 'Pago tarjeta');
 
         // Owner can list it
         $listOwner = $this->getJson('/api/recurring-payments');

--- a/tests/Feature/SendRecurringPaymentRemindersCommandTest.php
+++ b/tests/Feature/SendRecurringPaymentRemindersCommandTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Illuminate\Support\Carbon;
+use App\Models\User;
+use App\Models\RecurringPayment;
+
+class SendRecurringPaymentRemindersCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_outputs_reminder(): void
+    {
+        Carbon::setTestNow('2025-01-01');
+
+        $user = User::create([
+            'id' => (string) Str::uuid(),
+            'name' => 'Owner',
+            'email' => 'owner@example.com',
+        ]);
+
+        RecurringPayment::create([
+            'id' => (string) Str::uuid(),
+            'user_id' => $user->id,
+            'title' => 'Pago tarjeta',
+            'description' => 'Pago tarjeta',
+            'amount_monthly' => 100,
+            'months' => 12,
+            'start_date' => '2025-01-10',
+            'day_of_month' => 10,
+            'reminder_days_before' => 9,
+        ]);
+
+        $this->artisan('recurring-payments:send-reminders')
+            ->expectsOutput("Reminder for payment Pago tarjeta to user {$user->id}")
+            ->assertExitCode(0);
+    }
+}


### PR DESCRIPTION
## Summary
- add title, scheduling and reminder fields to recurring payments
- support new fields in API and documentation
- introduce command to emit reminders for upcoming payments

## Testing
- `composer install --no-interaction` *(fails: unable to access github.com)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b50d0d471c832481b3624a9f828c5b