### PR TITLE
Ensure unique device token and handle conflicts

### DIFF
--- a/database/migrations/2025_09_01_140000_add_unique_device_token_to_user_devices_table.php
+++ b/database/migrations/2025_09_01_140000_add_unique_device_token_to_user_devices_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('user_devices', function (Blueprint $table) {
+            $table->unique('device_token');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('user_devices', function (Blueprint $table) {
+            $table->dropUnique(['device_token']);
+        });
+    }
+};

--- a/tests/Feature/NotificationControllerTest.php
+++ b/tests/Feature/NotificationControllerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
+use Illuminate\Support\Str;
+
+class NotificationControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_register_device_token_is_unique(): void
+    {
+        $user1 = User::create([
+            'id' => (string) Str::uuid(),
+            'name' => 'User One',
+            'email' => 'one@example.com',
+        ]);
+
+        $user2 = User::create([
+            'id' => (string) Str::uuid(),
+            'name' => 'User Two',
+            'email' => 'two@example.com',
+        ]);
+
+        $token = 'tok-123';
+
+        $this->actingAs($user1, 'sanctum');
+        $this->postJson('/api/notifications/register-device', [
+            'device_token' => $token,
+            'device_type' => 'android',
+        ])->assertStatus(201);
+
+        $this->actingAs($user2, 'sanctum');
+        $this->postJson('/api/notifications/register-device', [
+            'device_token' => $token,
+            'device_type' => 'android',
+        ])->assertStatus(200)
+          ->assertJson(['message' => 'Dispositivo actualizado']);
+
+        $this->assertDatabaseCount('user_devices', 1);
+        $this->assertDatabaseHas('user_devices', [
+            'device_token' => $token,
+            'user_id' => $user2->id,
+            'device_type' => 'android',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add unique index on `user_devices.device_token`
- handle unique constraint violations when registering devices
- test that registering same token moves it between users

## Testing
- `composer install` *(fails: CONNECT tunnel failed, GitHub credentials required)*
- `php artisan test` *(fails: vendor autoload not found)*
- `php -l app/Http/Controllers/Api/NotificationController.php`
- `php -l database/migrations/2025_09_01_140000_add_unique_device_token_to_user_devices_table.php`
- `php -l tests/Feature/NotificationControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b65e2fdafc832495e2fbd3ceb2e895