### PR TITLE
Ensure registration token single-use with row locking

### DIFF
--- a/tests/Feature/AuthControllerTest.php
+++ b/tests/Feature/AuthControllerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\Group;
 use App\Models\User;
+use App\Models\RegistrationToken;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
@@ -103,5 +104,44 @@ class AuthControllerTest extends TestCase
             ->assertJson([
                 'message' => 'Cuenta desactivada',
             ]);
+    }
+
+    public function test_registration_token_is_consumed_only_once_concurrently(): void
+    {
+        $email = 'concurrent@example.com';
+        $regToken = RegistrationToken::create([
+            'id' => (string) Str::uuid(),
+            'email' => $email,
+            'token' => Str::random(40),
+            'status' => 'pending',
+        ]);
+
+        $payload = [
+            'name' => 'Test User',
+            'email' => $email,
+            'password' => 'secret123',
+            'password_confirmation' => 'secret123',
+            'registration_token' => $regToken->token,
+        ];
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'child');
+
+        $pid = pcntl_fork();
+        if ($pid === 0) {
+            DB::disconnect();
+            DB::reconnect();
+            $response = $this->postJson('/api/auth/register', $payload);
+            file_put_contents($tempFile, (string) $response->status());
+            exit(0);
+        }
+
+        $responseParent = $this->postJson('/api/auth/register', $payload);
+        pcntl_wait($status);
+        $childStatus = (int) file_get_contents($tempFile);
+        @unlink($tempFile);
+
+        $this->assertEqualsCanonicalizing([201, 422], [$responseParent->status(), $childStatus]);
+        $this->assertSame('used', $regToken->fresh()->status);
+        $this->assertEquals(1, User::where('email', $email)->count());
     }
 }


### PR DESCRIPTION
## Summary
- Lock registration token for update inside registration transaction and update only when pending
- Add concurrent test verifying a registration token is consumed only once

## Testing
- `composer test` *(fails: require GitHub token for dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_68b65e4056548324a6876c5fa25fa89e