### PR TITLE
Normalize emails and enforce case-insensitive uniqueness

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -36,6 +36,11 @@ class User extends Authenticatable
         'is_active' => 'boolean',
     ];
 
+    public function setEmailAttribute($value)
+    {
+        $this->attributes['email'] = mb_strtolower($value);
+    }
+
     public function groups()
     {
         // Si la pivot NO tiene created_at/updated_at, no uses withTimestamps()

--- a/database/migrations/2025_08_27_021925_baseline_schema_from_dump.php
+++ b/database/migrations/2025_08_27_021925_baseline_schema_from_dump.php
@@ -50,13 +50,16 @@ return new class extends Migration
             CREATE TABLE IF NOT EXISTS public.users (
                 id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
                 name varchar(100) NOT NULL,
-                email varchar(255) NOT NULL UNIQUE,
+                email varchar(255) NOT NULL,
                 password_hash text NOT NULL,
                 profile_picture_url text,
                 phone_number varchar(50),
                 created_at timestamptz DEFAULT CURRENT_TIMESTAMP,
                 updated_at timestamptz DEFAULT CURRENT_TIMESTAMP
             );
+
+            CREATE UNIQUE INDEX IF NOT EXISTS users_email_lower_unique
+                ON public.users (LOWER(email));
 
             CREATE TABLE IF NOT EXISTS public.groups (
                 id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -260,6 +263,7 @@ return new class extends Migration
 
         // Borra tablas (en orden por FKs)
         DB::unprepared("
+            DROP INDEX IF EXISTS public.users_email_lower_unique;
             DROP TABLE IF EXISTS public.expense_participants CASCADE;
             DROP TABLE IF EXISTS public.invitations CASCADE;
             DROP TABLE IF EXISTS public.expenses CASCADE;

--- a/tests/Feature/UserEmailTest.php
+++ b/tests/Feature/UserEmailTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserEmailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_emails_are_unique_case_insensitively(): void
+    {
+        User::factory()->create(['email' => 'User@example.com']);
+
+        $this->expectException(QueryException::class);
+        User::factory()->create(['email' => 'user@example.com']);
+    }
+}
+


### PR DESCRIPTION
## Summary
- lower-case emails automatically in the `User` model
- add unique index on `LOWER(email)` and drop column unique constraint
- test that email uniqueness is case-insensitive

## Testing
- `composer install` *(fails: Failed to download doctrine/inflector from dist: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68b65e5fb0d88324bcd0b0cb29954bc0