### PR TITLE
Add MODE_APP configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
+MODE_APP=private
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Variables principales:
 |-----------------|--------------------------------------------------|
 | `APP_NAME`      | Nombre mostrado de la aplicación.                |
 | `APP_URL`       | URL base del backend.                            |
+| `MODE_APP`      | Modo de la aplicación (`private` o `public`).    |
 | `APP_KEY`       | Clave generada con `php artisan key:generate`.   |
 | `DB_CONNECTION` | Motor de base de datos (usar `pgsql`).           |
 | `DB_HOST`       | Host del servidor PostgreSQL.                    |

--- a/config/app.php
+++ b/config/app.php
@@ -43,6 +43,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application Mode
+    |--------------------------------------------------------------------------
+    |
+    | This value determines the mode of your application, allowing you to
+    | switch between "private" and "public" modes depending on your needs.
+    |
+    */
+
+    'mode_app' => env('MODE_APP', 'private'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application URL
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
## Summary
- add `MODE_APP` to `.env.example`
- expose `mode_app` config in `config/app.php`
- document `MODE_APP` valid values in README

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b835070a608324b2ce2123fd0308d6