### PR TITLE
Clarify registration token usage and MODE_APP setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
+MODE_APP=private
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Variables principales:
 | `DB_DATABASE`   | Nombre de la base de datos.                      |
 | `DB_USERNAME`   | Usuario con acceso a la base.                    |
 | `DB_PASSWORD`   | Contraseña del usuario.                          |
+| `MODE_APP`      | `private` exige `registration_token`; `public` permite registro abierto. |
 
 Ejemplo de configuración:
 
@@ -84,6 +85,14 @@ DB_PASSWORD=postgres
 ```
 
 El proyecto está pensado para PostgreSQL. Ajusta las variables anteriores según tu entorno.
+
+El modo de la aplicación se controla con `MODE_APP`. Tras cambiarlo en el `.env` ejecuta:
+
+```bash
+php artisan config:clear
+```
+
+En modo `private` el endpoint `POST /api/auth/register` requiere un `registration_token`. En modo `public` este campo no es necesario y cualquiera puede registrarse.
 
 ## Comandos básicos
 
@@ -143,7 +152,7 @@ Token de invitación para newuser@example.com:
 INVTOKEN456...
 ```
 
-Con estos tokens se puede registrar un usuario con el endpoint:
+El `registration_token` solo es necesario cuando `MODE_APP=private`. Con estos tokens se puede registrar un usuario con el endpoint:
 
 ```http
 POST /api/auth/register
@@ -152,8 +161,8 @@ POST /api/auth/register
   "email": "newuser@example.com",
   "password": "secret1234",
   "password_confirmation": "secret1234",
-  "registration_token": "REGTOKEN123...",
-  "invitation_token": "INVTOKEN456..."
+  "registration_token": "REGTOKEN123...", // requerido en modo privado
+  "invitation_token": "INVTOKEN456..." // opcional
 }
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,6 +2,13 @@
 
 Todas las rutas están bajo el prefijo `/api`. A menos que se indique lo contrario, los endpoints requieren autenticación con un token de Laravel Sanctum enviado en el encabezado `Authorization: Bearer {token}`.
 
+La aplicación opera en dos modos controlados por la variable de entorno `MODE_APP`:
+
+- `private`: el registro de usuarios exige un `registration_token` válido.
+- `public`: el registro es abierto y no necesita `registration_token`.
+
+Para cambiar el modo edita el archivo `.env`, ajusta `MODE_APP` y ejecuta `php artisan config:clear`.
+
 ## Flujos completos
 
 ### Autenticación - Login
@@ -151,7 +158,7 @@ POST /api/notifications/register-device
 
 2. **Registrar un usuario con los tokens**
 
-   El invitado usa el `registration_token` recibido y opcionalmente el `group_token` para registrarse vía `POST /api/auth/register`.
+  Si `MODE_APP=private`, el invitado usa el `registration_token` recibido y opcionalmente el `group_token` para registrarse vía `POST /api/auth/register`. En modo `public` puede registrarse sin `registration_token`.
 
    ```http
    POST /api/auth/register
@@ -182,7 +189,7 @@ POST /api/notifications/register-device
 
    Si el correo no está asociado a un usuario, la invitación genera **dos** tokens:
 
-   - `registration_token`: para crear la cuenta mediante `POST /api/auth/register`.
+  - `registration_token`: para crear la cuenta mediante `POST /api/auth/register` (solo en modo `private`).
    - `group_token` (`invitation_token`): para unirse al grupo después del registro mediante `POST /api/invitations/accept`.
 
    El cliente debe manejar ambos tokens en el flujo de alta de usuario.
@@ -197,7 +204,7 @@ Registra un usuario utilizando un token de registro.
 - `email` (string, requerido)
 - `password` (string, min 8, requerido)
 - `password_confirmation` (string, debe coincidir)
-- `registration_token` (string, requerido)
+- `registration_token` (string, requerido en modo `private`)
 - `invitation_token` (string, opcional)
 - `profile_picture_url` (url, opcional)
 - `phone_number` (string, opcional)

--- a/docs/api.http
+++ b/docs/api.http
@@ -2,6 +2,7 @@
 @token = {{token}}
 
 ### Register
+# Si MODE_APP=private, incluye `registration_token`; en `public` omite este campo.
 POST {{baseUrl}}/auth/register
 Content-Type: application/json
 

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -2,6 +2,10 @@ openapi: 3.0.0
 info:
   title: Gestión Financiera API
   version: '1.0.0'
+  description: >
+    La variable de entorno MODE_APP controla el modo de registro. En `private` se
+    exige `registration_token`; en `public` el registro es abierto. Tras cambiarla
+    en el `.env`, ejecutar `php artisan config:clear`.
 servers:
   - url: http://localhost/api
     description: Desarrollo local
@@ -24,7 +28,7 @@ paths:
           application/json:
             schema:
               type: object
-              required: [name, email, password, password_confirmation, registration_token]
+              required: [name, email, password, password_confirmation]
               properties:
                 name:
                   type: string
@@ -39,6 +43,7 @@ paths:
                   format: password
                 registration_token:
                   type: string
+                  description: Requerido solo cuando MODE_APP=private
                 invitation_token:
                   type: string
                 profile_picture_url:
@@ -51,7 +56,7 @@ paths:
               email: juan@example.com
               password: secret123
               password_confirmation: secret123
-              registration_token: REG123
+              registration_token: REG123 # requerido en modo private
               invitation_token: ABC123
       responses:
         '201':

--- a/terminal.md
+++ b/terminal.md
@@ -1,4 +1,6 @@
-Peticiones de postman para la documentacion y arreglo de problemas 
+Peticiones de postman para la documentacion y arreglo de problemas
+
+Los ejemplos se generaron con `MODE_APP=private`, donde el campo `registration_token` es obligatorio al registrarse. Para permitir registros sin token cambia a `MODE_APP=public` en el `.env` y ejecuta `php artisan config:clear`.
 
 POST http://localhost:8000/api/auth/login: {
   "Network": {


### PR DESCRIPTION
## Summary
- Document MODE_APP environment variable to switch between private (token-required) and public registration
- Clarify that `registration_token` is only required in private mode across README, API docs, and examples

## Testing
- `composer test` *(failed: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*
- `composer install` *(failed: GitHub rate limit requiring authentication token)*

------
https://chatgpt.com/codex/tasks/task_e_68b835132d348324aa5ac20ee81375d7