### PR TITLE
docs: document app mode endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ php artisan config:clear
 
 En modo `private` el endpoint `POST /api/auth/register` requiere un `registration_token`. En modo `public` este campo no es necesario y cualquiera puede registrarse.
 
+Para conocer el modo actual de la aplicación existe el endpoint público:
+
+```http
+GET /api/app-mode
+```
+
+Que devuelve un JSON con la forma:
+
+```json
+{
+  "mode": "public"
+}
+```
+
 ## Comandos básicos
 
 | Comando                     | Descripción                                      |

--- a/docs/API.md
+++ b/docs/API.md
@@ -9,6 +9,17 @@ La aplicación opera en dos modos controlados por la variable de entorno `MODE_A
 
 Para cambiar el modo edita el archivo `.env`, ajusta `MODE_APP` y ejecuta `php artisan config:clear`.
 
+### GET /api/app-mode
+Devuelve el modo actual de la aplicación (`public` o `private`).
+No requiere autenticación.
+
+#### Respuesta
+```json
+{
+  "mode": "public"
+}
+```
+
 ## Flujos completos
 
 ### Autenticación - Login

--- a/docs/api.http
+++ b/docs/api.http
@@ -1,6 +1,9 @@
 @baseUrl = http://localhost/api
 @token = {{token}}
 
+### Get app mode
+GET {{baseUrl}}/app-mode
+
 ### Register
 # Si MODE_APP=private, incluye `registration_token`; en `public` omite este campo.
 POST {{baseUrl}}/auth/register

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -18,6 +18,20 @@ components:
 security:
   - sanctum: []
 paths:
+  /app-mode:
+    get:
+      summary: Obtiene el modo actual de la aplicación
+      description: Devuelve `public` o `private`
+      security: []
+      responses:
+        '200':
+          description: Modo actual
+          content:
+            application/json:
+              examples:
+                success:
+                  value:
+                    mode: public
   /auth/register:
     post:
       summary: Registra un usuario a partir de una invitación

--- a/docs/postman_collection.json
+++ b/docs/postman_collection.json
@@ -6,6 +6,48 @@
   },
   "item": [
     {
+      "name": "App",
+      "item": [
+        {
+          "name": "Get App Mode",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/app-mode",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "app-mode"
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "200",
+              "originalRequest": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/app-mode",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "app-mode"
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "body": "{\n  \"mode\": \"public\"\n}"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "Auth",
       "item": [
         {


### PR DESCRIPTION
## Summary
- describe `GET /api/app-mode` and its JSON response
- include app mode endpoint in OpenAPI, http examples, and Postman collection

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/gestion-financiera/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68b85707a5948324a524b2c87da1b944