### PR TITLE
Add app mode endpoint

### DIFF
--- a/app/Http/Controllers/Api/AppModeController.php
+++ b/app/Http/Controllers/Api/AppModeController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+
+class AppModeController extends Controller
+{
+    public function show(): JsonResponse
+    {
+        return response()->json([
+            'mode_app' => config('app.mode_app'),
+        ]);
+    }
+}
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Api\NotificationController;
 use App\Http\Controllers\Api\DashboardController;
 use App\Http\Controllers\Api\ReportController;
 use App\Http\Controllers\Api\RecurringPaymentController;
+use App\Http\Controllers\Api\AppModeController;
 
 /**
  * RUTAS PÚBLICAS (sin auth)
@@ -22,6 +23,8 @@ use App\Http\Controllers\Api\RecurringPaymentController;
 
 Route::get('invitations/token/{token}', [InvitationController::class, 'verifyToken'])
     ->name('invitations.verify');
+
+Route::get('app-mode', [AppModeController::class, 'show']);
 
 Route::prefix('auth')->group(function () {
     Route::post('/register', [AuthController::class, 'register']);

--- a/tests/Feature/AppModeControllerTest.php
+++ b/tests/Feature/AppModeControllerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class AppModeControllerTest extends TestCase
+{
+    public function test_show_returns_private_mode(): void
+    {
+        config(['app.mode_app' => 'private']);
+
+        $response = $this->getJson('/api/app-mode');
+
+        $response->assertStatus(200)
+            ->assertExactJson(['mode_app' => 'private']);
+    }
+
+    public function test_show_returns_public_mode(): void
+    {
+        config(['app.mode_app' => 'public']);
+
+        $response = $this->getJson('/api/app-mode');
+
+        $response->assertStatus(200)
+            ->assertExactJson(['mode_app' => 'public']);
+    }
+}
+


### PR DESCRIPTION
## Summary
- expose app mode via new controller and route
- test app mode response for private and public settings

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68b8570671408324824b92e8f00678f2