### PR TITLE
Drop unused recurring_payment_viewers table

### DIFF
--- a/database/migrations/2025_08_28_000000_create_recurring_payments_table.php
+++ b/database/migrations/2025_08_28_000000_create_recurring_payments_table.php
@@ -21,14 +21,6 @@ return new class extends Migration
             $table->timestampsTz();
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
-
-        Schema::create('recurring_payment_viewers', function (Blueprint $table) {
-            $table->uuid('recurring_payment_id');
-            $table->uuid('user_id');
-            $table->primary(['recurring_payment_id', 'user_id']);
-            $table->foreign('recurring_payment_id')->references('id')->on('recurring_payments')->onDelete('cascade');
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
-        });
     }
 
     public function down(): void

--- a/database/migrations/2025_09_02_000000_drop_recurring_payment_viewers_table.php
+++ b/database/migrations/2025_09_02_000000_drop_recurring_payment_viewers_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::dropIfExists('recurring_payment_viewers');
+    }
+
+    public function down(): void
+    {
+        Schema::create('recurring_payment_viewers', function (Blueprint $table) {
+            $table->uuid('recurring_payment_id');
+            $table->uuid('user_id');
+            $table->primary(['recurring_payment_id', 'user_id']);
+            $table->foreign('recurring_payment_id')
+                ->references('id')->on('recurring_payments')->onDelete('cascade');
+            $table->foreign('user_id')
+                ->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- stop creating `recurring_payment_viewers` in the recurring payments migration
- add follow-up migration to drop `recurring_payment_viewers`

## Testing
- `composer test` *(fails: require(/workspace/gestion-financiera/vendor/autoload.php): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cda4c0908324b022deae16a317b8