### PR TITLE
Remove recurring payment sharing

### DIFF
--- a/app/Http/Controllers/Api/RecurringPaymentController.php
+++ b/app/Http/Controllers/Api/RecurringPaymentController.php
@@ -15,13 +15,8 @@ class RecurringPaymentController extends Controller
         $userId = $request->user()->id;
 
         $items = DB::table('recurring_payments as rp')
-            ->leftJoin('recurring_payment_viewers as rpv', 'rpv.recurring_payment_id', '=', 'rp.id')
-            ->where(function ($q) use ($userId) {
-                $q->where('rp.user_id', $userId)
-                  ->orWhere('rpv.user_id', $userId);
-            })
+            ->where('rp.user_id', $userId)
             ->select('rp.*')
-            ->distinct()
             ->get();
 
         return response()->json($items, 200);
@@ -39,34 +34,24 @@ class RecurringPaymentController extends Controller
             'start_date'          => ['required', 'date'],
             'day_of_month'        => ['required', 'integer', 'between:1,31'],
             'reminder_days_before'=> ['required', 'integer', 'min:0'],
-            'shared_with'         => ['sometimes', 'array'],
-            'shared_with.*'       => ['uuid', 'exists:users,id'],
         ]);
 
         $id = (string) Str::uuid();
 
         DB::transaction(function () use ($data, $id, $userId) {
             DB::table('recurring_payments')->insert([
-                'id'             => $id,
-                'user_id'             => $userId,
-                'title'               => $data['title'],
-                'description'         => $data['description'],
-                'amount_monthly'      => $data['amount_monthly'],
-                'months'              => $data['months'],
-                'start_date'          => $data['start_date'],
-                'day_of_month'        => $data['day_of_month'],
+                'id'                => $id,
+                'user_id'           => $userId,
+                'title'             => $data['title'],
+                'description'       => $data['description'],
+                'amount_monthly'    => $data['amount_monthly'],
+                'months'            => $data['months'],
+                'start_date'        => $data['start_date'],
+                'day_of_month'      => $data['day_of_month'],
                 'reminder_days_before'=> $data['reminder_days_before'],
-                'created_at'          => now(),
-                'updated_at'          => now(),
+                'created_at'        => now(),
+                'updated_at'        => now(),
             ]);
-
-            if (!empty($data['shared_with'])) {
-                $rows = collect($data['shared_with'])->map(fn ($uid) => [
-                    'recurring_payment_id' => $id,
-                    'user_id'              => $uid,
-                ])->all();
-                DB::table('recurring_payment_viewers')->insert($rows);
-            }
         });
 
         $item = DB::table('recurring_payments')->where('id', $id)->first();

--- a/app/Models/RecurringPayment.php
+++ b/app/Models/RecurringPayment.php
@@ -35,8 +35,4 @@ class RecurringPayment extends Model
         return $this->belongsTo(User::class, 'user_id');
     }
 
-    public function viewers()
-    {
-        return $this->belongsToMany(User::class, 'recurring_payment_viewers');
-    }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -404,7 +404,7 @@ El receptor rechaza el pago y libera deudas asociadas.
 ## Pagos recurrentes
 
 ### GET /api/recurring-payments
-Lista pagos recurrentes creados por el usuario o compartidos con él.
+Lista pagos recurrentes creados por el usuario.
 
 ### POST /api/recurring-payments
 Crea un nuevo pago recurrente para recordar deudas periódicas.
@@ -417,7 +417,6 @@ Crea un nuevo pago recurrente para recordar deudas periódicas.
 - `start_date` (date, requerido, fecha del primer pago)
 - `day_of_month` (integer 1-31, requerido, día del mes para el cobro)
 - `reminder_days_before` (integer, requerido, días de anticipación para recordar)
-- `shared_with` (array de UUID, opcional, usuarios invitados como lectores)
 
 ## Notificaciones
 

--- a/docs/ssds_api_full_ALINEADO.postman_collection.json
+++ b/docs/ssds_api_full_ALINEADO.postman_collection.json
@@ -1,8 +1,8 @@
 {
     "info": {
-        "name": "SSDS API – Full Test (CORREGIDO)",
+        "name": "SSDS API \u2013 Full Test (CORREGIDO)",
         "_postman_id": "e4fed3f4-f133-4112-ac17-bb505cb725ec",
-        "description": "Colección corregida para capturar variables según respuestas reales.",
+        "description": "Colecci\u00f3n corregida para capturar variables seg\u00fan respuestas reales.",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
     },
     "item": [
@@ -10,7 +10,7 @@
             "name": "00 Info",
             "item": [
                 {
-                    "name": "App Mode (público)",
+                    "name": "App Mode (p\u00fablico)",
                     "request": {
                         "method": "GET",
                         "header": [
@@ -533,7 +533,7 @@
                     ]
                 },
                 {
-                    "name": "Verificar invitación (pública) User1",
+                    "name": "Verificar invitaci\u00f3n (p\u00fablica) User1",
                     "request": {
                         "method": "GET",
                         "header": [
@@ -564,7 +564,7 @@
                     }
                 },
                 {
-                    "name": "Verificar invitación (pública) User2",
+                    "name": "Verificar invitaci\u00f3n (p\u00fablica) User2",
                     "request": {
                         "method": "GET",
                         "header": [
@@ -595,7 +595,7 @@
                     }
                 },
                 {
-                    "name": "Verificar invitación (pública) User3",
+                    "name": "Verificar invitaci\u00f3n (p\u00fablica) User3",
                     "request": {
                         "method": "GET",
                         "header": [
@@ -840,7 +840,7 @@
                     ]
                 },
                 {
-                    "name": "User1: Aceptar invitación (invitation.token)",
+                    "name": "User1: Aceptar invitaci\u00f3n (invitation.token)",
                     "request": {
                         "method": "POST",
                         "header": [
@@ -1127,7 +1127,7 @@
                     ]
                 },
                 {
-                    "name": "User2: Aceptar invitación (invitation.token)",
+                    "name": "User2: Aceptar invitaci\u00f3n (invitation.token)",
                     "request": {
                         "method": "POST",
                         "header": [
@@ -1414,7 +1414,7 @@
                     ]
                 },
                 {
-                    "name": "User3: Aceptar invitación (invitation.token)",
+                    "name": "User3: Aceptar invitaci\u00f3n (invitation.token)",
                     "request": {
                         "method": "POST",
                         "header": [
@@ -2115,7 +2115,7 @@
             "name": "05 Pagos (aprobado y rechazado)",
             "item": [
                 {
-                    "name": "Pago1: User2 ➜ User1 (GA)",
+                    "name": "Pago1: User2 \u279c User1 (GA)",
                     "request": {
                         "method": "POST",
                         "header": [
@@ -2238,7 +2238,7 @@
                     ]
                 },
                 {
-                    "name": "Pago2: User3 ➜ Owner (GB)",
+                    "name": "Pago2: User3 \u279c Owner (GB)",
                     "request": {
                         "method": "POST",
                         "header": [
@@ -2448,7 +2448,7 @@
                         },
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"title\": \"{{recurring_title}}\",\n  \"description\": \"{{recurring_description}}\",\n  \"amount_monthly\": {{recurring_amount_monthly}},\n  \"months\": {{recurring_months}},\n  \"start_date\": \"{{recurring_start_date}}\",\n  \"day_of_month\": {{recurring_day_of_month}},\n  \"reminder_days_before\": {{recurring_reminder_days_before}},\n  \"shared_with\": [\n    \"{{user2_id}}\",\n    \"{{user3_id}}\"\n  ]\n}"
+                            "raw": "{\n  \"title\": \"{{recurring_title}}\",\n  \"description\": \"{{recurring_description}}\",\n  \"amount_monthly\": {{recurring_amount_monthly}},\n  \"months\": {{recurring_months}},\n  \"start_date\": \"{{recurring_start_date}}\",\n  \"day_of_month\": {{recurring_day_of_month}},\n  \"reminder_days_before\": {{recurring_reminder_days_before}}\n}"
                         },
                         "auth": {
                             "type": "noauth"
@@ -2510,7 +2510,7 @@
                         },
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"title\": \"{{recurring_title}}\",\n  \"description\": \"{{recurring_description}}\",\n  \"amount_monthly\": {{recurring_amount_monthly}},\n  \"months\": {{recurring_months}},\n  \"start_date\": \"{{recurring_start_date}}\",\n  \"day_of_month\": {{recurring_day_of_month}},\n  \"reminder_days_before\": {{recurring_reminder_days_before}},\n  \"shared_with\": [\n    \"{{user1_id}}\"\n  ]\n}"
+                            "raw": "{\n  \"title\": \"{{recurring_title}}\",\n  \"description\": \"{{recurring_description}}\",\n  \"amount_monthly\": {{recurring_amount_monthly}},\n  \"months\": {{recurring_months}},\n  \"start_date\": \"{{recurring_start_date}}\",\n  \"day_of_month\": {{recurring_day_of_month}},\n  \"reminder_days_before\": {{recurring_reminder_days_before}}\n}"
                         },
                         "auth": {
                             "type": "noauth"
@@ -2572,7 +2572,7 @@
                         },
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"title\": \"{{recurring_title}}\",\n  \"description\": \"{{recurring_description}}\",\n  \"amount_monthly\": {{recurring_amount_monthly}},\n  \"months\": {{recurring_months}},\n  \"start_date\": \"{{recurring_start_date}}\",\n  \"day_of_month\": {{recurring_day_of_month}},\n  \"reminder_days_before\": {{recurring_reminder_days_before}},\n  \"shared_with\": [\n    \"{{user1_id}}\",\n    \"{{user2_id}}\"\n  ]\n}"
+                            "raw": "{\n  \"title\": \"{{recurring_title}}\",\n  \"description\": \"{{recurring_description}}\",\n  \"amount_monthly\": {{recurring_amount_monthly}},\n  \"months\": {{recurring_months}},\n  \"start_date\": \"{{recurring_start_date}}\",\n  \"day_of_month\": {{recurring_day_of_month}},\n  \"reminder_days_before\": {{recurring_reminder_days_before}}\n}"
                         },
                         "auth": {
                             "type": "noauth"
@@ -2863,7 +2863,7 @@
             "name": "09 Cambios/Logout/Eliminar",
             "item": [
                 {
-                    "name": "User1: cambiar contraseña",
+                    "name": "User1: cambiar contrase\u00f1a",
                     "request": {
                         "method": "PUT",
                         "header": [
@@ -3049,7 +3049,7 @@
                     ]
                 },
                 {
-                    "name": "User2: actualizar teléfono",
+                    "name": "User2: actualizar tel\u00e9fono",
                     "request": {
                         "method": "PUT",
                         "header": [

--- a/terminal.md
+++ b/terminal.md
@@ -1429,7 +1429,7 @@ POST http://localhost:8000/api/recurring-payments: {
     "connection": "keep-alive",
     "content-length": "194"
   },
-  "Request Body": "{\n  \"description\": \"Renta departamento\",\n  \"amount_monthly\": 8000,\n  \"months\": 12,\n  \"shared_with\": [\n    \"6464d4c1-b815-4376-b477-42ce44ec1f67\",\n    \"d40825d4-4ed8-4008-afc9-27267d398129\"\n  ]\n}",
+  "Request Body": "{\n  \"description\": \"Renta departamento\",\n  \"amount_monthly\": 8000,\n  \"months\": 12\n}",
   "Response Headers": {
     "host": "localhost:8000",
     "connection": "close",
@@ -1467,7 +1467,7 @@ POST http://localhost:8000/api/recurring-payments: {
     "connection": "keep-alive",
     "content-length": "144"
   },
-  "Request Body": "{\n  \"description\": \"Internet hogar\",\n  \"amount_monthly\": 600,\n  \"months\": 6,\n  \"shared_with\": [\n    \"6464d4c1-b815-4376-b477-42ce44ec1f67\"\n  ]\n}",
+  "Request Body": "{\n  \"description\": \"Internet hogar\",\n  \"amount_monthly\": 600,\n  \"months\": 6\n}",
   "Response Headers": {
     "host": "localhost:8000",
     "connection": "close",
@@ -1505,7 +1505,7 @@ POST http://localhost:8000/api/recurring-payments: {
     "connection": "keep-alive",
     "content-length": "152"
   },
-  "Request Body": "{\n  \"description\": \"Mantenimiento oficina\",\n  \"amount_monthly\": 1200,\n  \"months\": 3,\n  \"shared_with\": [\n    \"b078c0ee-803e-44f4-a9e3-c80a3bcca963\"\n  ]\n}",
+  "Request Body": "{\n  \"description\": \"Mantenimiento oficina\",\n  \"amount_monthly\": 1200,\n  \"months\": 3\n}",
   "Response Headers": {
     "host": "localhost:8000",
     "connection": "close",

--- a/tests/Feature/RecurringPaymentControllerTest.php
+++ b/tests/Feature/RecurringPaymentControllerTest.php
@@ -11,18 +11,12 @@ class RecurringPaymentControllerTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_user_can_create_and_share_recurring_payment(): void
+    public function test_user_can_create_recurring_payment(): void
     {
         $owner = User::create([
             'id' => (string) Str::uuid(),
             'name' => 'Owner',
             'email' => 'owner@example.com',
-        ]);
-
-        $viewer = User::create([
-            'id' => (string) Str::uuid(),
-            'name' => 'Viewer',
-            'email' => 'viewer@example.com',
         ]);
 
         $this->actingAs($owner, 'sanctum');
@@ -35,7 +29,6 @@ class RecurringPaymentControllerTest extends TestCase
             'start_date' => '2025-01-01',
             'day_of_month' => 1,
             'reminder_days_before' => 3,
-            'shared_with' => [$viewer->id],
         ];
 
         $resp = $this->postJson('/api/recurring-payments', $payload);
@@ -44,10 +37,5 @@ class RecurringPaymentControllerTest extends TestCase
         // Owner can list it
         $listOwner = $this->getJson('/api/recurring-payments');
         $listOwner->assertStatus(200)->assertJsonFragment(['description' => 'Pago tarjeta']);
-
-        // Viewer can also list it
-        $this->actingAs($viewer, 'sanctum');
-        $listViewer = $this->getJson('/api/recurring-payments');
-        $listViewer->assertStatus(200)->assertJsonFragment(['description' => 'Pago tarjeta']);
     }
 }


### PR DESCRIPTION
## Summary
- simplify recurring payment queries to only include owner's records
- drop viewers relation and shared_with documentation
- update tests and examples to remove sharing

## Testing
- `php -l app/Http/Controllers/Api/RecurringPaymentController.php`
- `php -l app/Models/RecurringPayment.php`
- `php -l tests/Feature/RecurringPaymentControllerTest.php`
- `composer install` *(failed: CONNECT tunnel failed 403 requiring GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cda35df08324a3603893ba57306a