### PR TITLE
Implementar validación con FormRequest en controladores

### DIFF
--- a/app/Http/Controllers/Api/NotificationController.php
+++ b/app/Http/Controllers/Api/NotificationController.php
@@ -3,12 +3,11 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Validation\Rule;
 use Illuminate\Support\Str;
 use Illuminate\Database\QueryException;
+use App\Http\Requests\Notification\RegisterDeviceRequest;
 
 class NotificationController extends Controller
 {
@@ -23,14 +22,11 @@ class NotificationController extends Controller
      *  - Si el token existe para el MISMO usuario => actualiza device_type si cambió (200).
      *  - Si el token existe para OTRO usuario => lo reasigna al usuario actual (200).
      */
-    public function registerDevice(Request $request): JsonResponse
+    public function registerDevice(RegisterDeviceRequest $request): JsonResponse
     {
         $user = $request->user();
 
-        $data = $request->validate([
-            'device_token' => ['required', 'string', 'max:4096'],
-            'device_type'  => ['required', Rule::in(['android', 'ios', 'web'])],
-        ]);
+        $data = $request->validated();
 
         $token = $data['device_token'];
         $type  = $data['device_type'];

--- a/app/Http/Controllers/Api/PaymentController.php
+++ b/app/Http/Controllers/Api/PaymentController.php
@@ -11,6 +11,8 @@ use Carbon\Carbon;
 use App\Models\Payment;
 use App\Jobs\SendPushNotification;
 use Illuminate\Validation\Rule;
+use App\Http\Requests\Payment\StorePaymentRequest;
+use App\Http\Requests\Payment\ApprovePaymentRequest;
 
 class PaymentController extends Controller
 {
@@ -64,19 +66,11 @@ class PaymentController extends Controller
         ], 200);
     }
 
-    public function store(Request $request): JsonResponse
+    public function store(StorePaymentRequest $request): JsonResponse
     {
         $userId = $request->user()->id;
 
-        $data = $request->validate([
-            'group_id'     => ['required', 'uuid'],
-            'from_user_id' => ['required', 'uuid'],
-            'to_user_id'   => ['required', 'uuid', 'different:from_user_id'],
-            'amount'       => ['required', 'numeric', 'gt:0'],
-            'note'         => ['sometimes', 'nullable', 'string'],
-            'evidence_url' => ['sometimes', 'nullable', 'url'],
-            'payment_method' => ['sometimes', 'nullable', 'string', Rule::in(['cash', 'transfer'])],
-        ]);
+        $data = $request->validated();
 
         if ($data['from_user_id'] !== $userId) {
             return response()->json(['message' => 'No puedes crear pagos a nombre de otro usuario'], 403);
@@ -198,7 +192,7 @@ class PaymentController extends Controller
         ], 200);
     }
 
-    public function approve(string $paymentId, Request $request): JsonResponse
+    public function approve(string $paymentId, ApprovePaymentRequest $request): JsonResponse
     {
         $userId = $request->user()->id;
 

--- a/app/Http/Controllers/Api/ReportController.php
+++ b/app/Http/Controllers/Api/ReportController.php
@@ -3,31 +3,32 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
+use App\Http\Requests\Report\ReportFilterRequest;
 
 class ReportController extends Controller
 {
-    public function index(Request $request): JsonResponse
+    public function index(ReportFilterRequest $request): JsonResponse
     {
-        $userId        = $request->user()->id;
-        $groupId       = $request->query('groupId');
+        $userId  = $request->user()->id;
+        $data    = $request->validated();
+        $groupId = $data['groupId'] ?? null;
 
-        $start         = $request->query('startDate')
-            ? Carbon::parse($request->query('startDate'))->startOfDay()
+        $start = isset($data['startDate'])
+            ? Carbon::parse($data['startDate'])->startOfDay()
             : now()->subDays(30)->startOfDay();
 
-        $end           = $request->query('endDate')
-            ? Carbon::parse($request->query('endDate'))->endOfDay()
+        $end   = isset($data['endDate'])
+            ? Carbon::parse($data['endDate'])->endOfDay()
             : now()->endOfDay();
 
-        $granularity   = $request->query('granularity', 'auto'); // day|month|auto
+        $granularity   = $data['granularity'] ?? 'auto'; // day|month|auto
         $grain         = $this->resolveGrain($granularity, $start, $end); // 'day' o 'month'
         $periodFormat  = $grain === 'day' ? 'YYYY-MM-DD' : 'YYYY-MM';
 
-        $paymentStatus = $request->query('paymentStatus', 'approved'); // approved|pending|rejected|any
+        $paymentStatus = $data['paymentStatus'] ?? 'approved'; // approved|pending|rejected|any
 
         // ============================
         // TOTALES (GASTOS)

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -11,7 +11,7 @@ class LoginRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -22,7 +22,8 @@ class LoginRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'email'    => ['required', 'email'],
+            'password' => ['required', 'string'],
         ];
     }
 }

--- a/app/Http/Requests/Auth/RegisterRequest.php
+++ b/app/Http/Requests/Auth/RegisterRequest.php
@@ -11,7 +11,7 @@ class RegisterRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -21,8 +21,18 @@ class RegisterRequest extends FormRequest
      */
     public function rules(): array
     {
+        $isPublic = config('app.mode_app') === 'public';
+
         return [
-            //
+            'name'                => ['required', 'string', 'max:100'],
+            'email'               => ['required', 'email', 'max:255', 'unique:users,email'],
+            'password'            => ['required', 'string', 'min:8', 'confirmed'],
+            'invitation_token'    => ['sometimes', 'nullable', 'string'],
+            'profile_picture_url' => ['sometimes', 'nullable', 'url'],
+            'phone_number'        => ['sometimes', 'nullable', 'string', 'max:50'],
+            'registration_token'  => $isPublic
+                ? ['sometimes', 'nullable', 'string']
+                : ['required', 'string'],
         ];
     }
 }

--- a/app/Http/Requests/Expense/ApproveExpenseRequest.php
+++ b/app/Http/Requests/Expense/ApproveExpenseRequest.php
@@ -11,7 +11,7 @@ class ApproveExpenseRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -21,8 +21,6 @@ class ApproveExpenseRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            //
-        ];
+        return [];
     }
 }

--- a/app/Http/Requests/Expense/StoreExpenseRequest.php
+++ b/app/Http/Requests/Expense/StoreExpenseRequest.php
@@ -11,7 +11,7 @@ class StoreExpenseRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -22,7 +22,17 @@ class StoreExpenseRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'description'               => ['required', 'string'],
+            'total_amount'              => ['required', 'numeric', 'min:0'],
+            'group_id'                  => ['required', 'uuid'],
+            'expense_date'              => ['required', 'date_format:Y-m-d'],
+
+            'has_ticket'                => ['required', 'boolean'],
+            'ticket_image_url'          => ['nullable', 'url', 'required_if:has_ticket,true', 'prohibited_unless:has_ticket,true'],
+
+            'participants'              => ['required', 'array', 'min:1'],
+            'participants.*.user_id'    => ['required', 'uuid'],
+            'participants.*.amount_due' => ['required', 'numeric', 'min:0'],
         ];
     }
 }

--- a/app/Http/Requests/Expense/UpdateExpenseRequest.php
+++ b/app/Http/Requests/Expense/UpdateExpenseRequest.php
@@ -11,7 +11,7 @@ class UpdateExpenseRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -22,7 +22,16 @@ class UpdateExpenseRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'description'               => ['sometimes', 'string'],
+            'total_amount'              => ['sometimes', 'numeric', 'min:0'],
+            'expense_date'              => ['sometimes', 'date_format:Y-m-d'],
+
+            'has_ticket'                => ['sometimes', 'boolean'],
+            'ticket_image_url'          => ['nullable', 'url', 'required_if:has_ticket,true', 'prohibited_unless:has_ticket,true'],
+
+            'participants'              => ['sometimes', 'array', 'min:1'],
+            'participants.*.user_id'    => ['required_with:participants', 'uuid'],
+            'participants.*.amount_due' => ['required_with:participants', 'numeric', 'min:0'],
         ];
     }
 }

--- a/app/Http/Requests/Group/AddMemberRequest.php
+++ b/app/Http/Requests/Group/AddMemberRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Group;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class AddMemberRequest extends FormRequest
 {
@@ -11,7 +12,7 @@ class AddMemberRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -22,7 +23,8 @@ class AddMemberRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'user_id' => ['required', 'uuid'],
+            'role'    => ['sometimes', Rule::in(['member', 'admin'])],
         ];
     }
 }

--- a/app/Http/Requests/Group/StoreGroupRequest.php
+++ b/app/Http/Requests/Group/StoreGroupRequest.php
@@ -11,7 +11,7 @@ class StoreGroupRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -22,7 +22,8 @@ class StoreGroupRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'name'        => ['required', 'string', 'max:150'],
+            'description' => ['sometimes', 'nullable', 'string'],
         ];
     }
 }

--- a/app/Http/Requests/Group/UpdateGroupRequest.php
+++ b/app/Http/Requests/Group/UpdateGroupRequest.php
@@ -11,7 +11,7 @@ class UpdateGroupRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -22,7 +22,8 @@ class UpdateGroupRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'name'        => ['sometimes', 'string', 'max:150'],
+            'description' => ['sometimes', 'nullable', 'string'],
         ];
     }
 }

--- a/app/Http/Requests/Group/UpdateMemberRoleRequest.php
+++ b/app/Http/Requests/Group/UpdateMemberRoleRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Group;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateMemberRoleRequest extends FormRequest
 {
@@ -11,7 +12,7 @@ class UpdateMemberRoleRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -22,7 +23,7 @@ class UpdateMemberRoleRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'role' => ['required', Rule::in(['member', 'admin', 'owner'])],
         ];
     }
 }

--- a/app/Http/Requests/Invitation/AcceptInvitationRequest.php
+++ b/app/Http/Requests/Invitation/AcceptInvitationRequest.php
@@ -11,7 +11,7 @@ class AcceptInvitationRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -22,7 +22,7 @@ class AcceptInvitationRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'token' => ['required', 'string'],
         ];
     }
 }

--- a/app/Http/Requests/Invitation/StoreInvitationRequest.php
+++ b/app/Http/Requests/Invitation/StoreInvitationRequest.php
@@ -11,7 +11,7 @@ class StoreInvitationRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -22,7 +22,9 @@ class StoreInvitationRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'invitee_email'   => ['required', 'email', 'max:255'],
+            'group_id'        => ['required', 'uuid'],
+            'expires_in_days' => ['sometimes', 'integer', 'min:1', 'max:90'],
         ];
     }
 }

--- a/app/Http/Requests/Notification/RegisterDeviceRequest.php
+++ b/app/Http/Requests/Notification/RegisterDeviceRequest.php
@@ -11,7 +11,7 @@ class RegisterDeviceRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -22,7 +22,8 @@ class RegisterDeviceRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'device_token' => ['required', 'string', 'max:4096'],
+            'device_type'  => ['required', 'in:android,ios,web'],
         ];
     }
 }

--- a/app/Http/Requests/Payment/ApprovePaymentRequest.php
+++ b/app/Http/Requests/Payment/ApprovePaymentRequest.php
@@ -11,7 +11,7 @@ class ApprovePaymentRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -21,8 +21,6 @@ class ApprovePaymentRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            //
-        ];
+        return [];
     }
 }

--- a/app/Http/Requests/Payment/StorePaymentRequest.php
+++ b/app/Http/Requests/Payment/StorePaymentRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Payment;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StorePaymentRequest extends FormRequest
 {
@@ -11,7 +12,7 @@ class StorePaymentRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -22,7 +23,13 @@ class StorePaymentRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'group_id'     => ['required', 'uuid'],
+            'from_user_id' => ['required', 'uuid'],
+            'to_user_id'   => ['required', 'uuid', 'different:from_user_id'],
+            'amount'       => ['required', 'numeric', 'gt:0'],
+            'note'         => ['sometimes', 'nullable', 'string'],
+            'evidence_url' => ['sometimes', 'nullable', 'url'],
+            'payment_method' => ['sometimes', 'nullable', 'string', Rule::in(['cash', 'transfer'])],
         ];
     }
 }

--- a/app/Http/Requests/Report/ReportFilterRequest.php
+++ b/app/Http/Requests/Report/ReportFilterRequest.php
@@ -11,7 +11,7 @@ class ReportFilterRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -22,7 +22,11 @@ class ReportFilterRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'groupId'      => ['sometimes', 'uuid'],
+            'startDate'    => ['sometimes', 'date_format:Y-m-d'],
+            'endDate'      => ['sometimes', 'date_format:Y-m-d'],
+            'granularity'  => ['sometimes', 'in:day,month,auto'],
+            'paymentStatus'=> ['sometimes', 'in:approved,pending,rejected,any'],
         ];
     }
 }


### PR DESCRIPTION
## Resumen
- Definir reglas de validación y `authorize()` en todas las FormRequest existentes
- Inyectar las FormRequest en los controladores correspondientes
- Eliminar validaciones embebidas y centralizar la lógica en las FormRequest

## Pruebas
- `composer test` *(falla: missing vendor/autoload.php)*
- `composer install` *(falla: requiere autenticación con GitHub)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2f34dc248324a2c3748d70be936f