### PR TITLE
Use API resources for expenses and payments

### DIFF
--- a/app/Http/Resources/ExpenseResource.php
+++ b/app/Http/Resources/ExpenseResource.php
@@ -14,6 +14,25 @@ class ExpenseResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        return parent::toArray($request);
+        return [
+            'id'               => $this->id,
+            'description'      => $this->description,
+            'total_amount'     => $this->formatMoney($this->total_amount),
+            'payer_id'         => $this->payer_id,
+            'group_id'         => $this->group_id,
+            'ticket_image_url' => $this->ticket_image_url,
+            'ocr_status'       => $this->ocr_status,
+            'status'           => $this->status,
+            'expense_date'     => $this->expense_date,
+            'created_at'       => $this->created_at ?? null,
+            'updated_at'       => $this->updated_at ?? null,
+            'participants'     => $this->when(isset($this->participants), $this->participants),
+            'role'             => $this->when(isset($this->role), $this->role),
+        ];
+    }
+
+    private function formatMoney($value): string
+    {
+        return number_format((float) ($value ?? 0), 2, '.', '');
     }
 }

--- a/app/Http/Resources/GroupResource.php
+++ b/app/Http/Resources/GroupResource.php
@@ -14,6 +14,14 @@ class GroupResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        return parent::toArray($request);
+        return [
+            'id'            => $this->id,
+            'name'          => $this->name,
+            'description'   => $this->description,
+            'owner_id'      => $this->owner_id,
+            'created_at'    => $this->created_at ?? null,
+            'my_role'       => $this->when(isset($this->my_role), $this->my_role),
+            'members_count' => $this->when(isset($this->members_count), (int) $this->members_count),
+        ];
     }
 }

--- a/app/Http/Resources/InvitationResource.php
+++ b/app/Http/Resources/InvitationResource.php
@@ -14,6 +14,16 @@ class InvitationResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        return parent::toArray($request);
+        return [
+            'id'            => $this->id,
+            'inviter_id'    => $this->inviter_id,
+            'invitee_email' => $this->invitee_email,
+            'group_id'      => $this->group_id,
+            'token'         => $this->token,
+            'status'        => $this->status,
+            'expires_at'    => $this->expires_at,
+            'created_at'    => $this->created_at ?? null,
+            'updated_at'    => $this->updated_at ?? null,
+        ];
     }
 }

--- a/app/Http/Resources/PaymentResource.php
+++ b/app/Http/Resources/PaymentResource.php
@@ -14,6 +14,27 @@ class PaymentResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        return parent::toArray($request);
+        return [
+            'id'               => $this->id,
+            'group_id'         => $this->group_id,
+            'amount'           => $this->formatMoney($this->amount),
+            'status'           => $this->status,
+            'payment_date'     => $this->payment_date,
+            'payment_method'   => $this->payment_method,
+            'note'             => $this->note,
+            'evidence_url'     => $this->evidence_url,
+            'from_user_id'     => $this->from_user_id,
+            'payer_name'       => $this->payer_name ?? null,
+            'to_user_id'       => $this->to_user_id,
+            'receiver_name'    => $this->receiver_name ?? null,
+            'direction'        => $this->direction ?? null,
+            'unapplied_amount' => $this->formatMoney($this->unapplied_amount ?? 0),
+            'participants'     => $this->when(isset($this->participants), $this->participants),
+        ];
+    }
+
+    private function formatMoney($value): string
+    {
+        return number_format((float) ($value ?? 0), 2, '.', '');
     }
 }

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -14,6 +14,14 @@ class UserResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        return parent::toArray($request);
+        return [
+            'id'                 => $this->id,
+            'name'               => $this->name,
+            'email'              => $this->email,
+            'profile_picture_url'=> $this->profile_picture_url,
+            'phone_number'       => $this->phone_number,
+            'created_at'         => $this->created_at ?? null,
+            'updated_at'         => $this->updated_at ?? null,
+        ];
     }
 }


### PR DESCRIPTION
## Summary
- implement JSON resources for users, groups, invitations, expenses and payments
- refactor expense and payment controllers to return resources, using resource collections for pagination

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: requires GitHub token / network access)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2f3fcf708324aa9468e316818763