### PR TITLE
Refactor expense and payment controllers to use services

### DIFF
--- a/app/Services/ExpenseService.php
+++ b/app/Services/ExpenseService.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\ProcessExpenseOcr;
+use App\Models\Expense;
+use App\Models\ExpenseParticipant;
+use Carbon\Carbon;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class ExpenseService
+{
+    public function listExpenses(string $userId, ?string $groupId, ?Carbon $start, ?Carbon $end): array
+    {
+        $query = Expense::with(['participants.user'])
+            ->where(function ($q) use ($userId) {
+                $q->where('payer_id', $userId)
+                    ->orWhereHas('participants', function ($qq) use ($userId) {
+                        $qq->where('user_id', $userId);
+                    });
+            })
+            ->when($groupId, fn($q) => $q->where('group_id', $groupId))
+            ->when($start, fn($q) => $q->whereDate('expense_date', '>=', $start))
+            ->when($end, fn($q) => $q->whereDate('expense_date', '<=', $end))
+            ->orderByDesc('expense_date')
+            ->orderByDesc('created_at');
+
+        /** @var LengthAwarePaginator $items */
+        $items = $query->paginate(15);
+
+        $data = $items->getCollection()->map(function (Expense $e) use ($userId) {
+            $participants = $e->participants->map(function (ExpenseParticipant $p) {
+                return [
+                    'id'         => $p->id,
+                    'user_id'    => $p->user_id,
+                    'user_name'  => $p->user?->name,
+                    'user_email' => $p->user?->email,
+                    'amount_due' => $this->money($p->amount_due),
+                    'is_paid'    => $p->is_paid,
+                    'payment_id' => $p->payment_id,
+                ];
+            })->values();
+
+            return [
+                'id'               => $e->id,
+                'description'      => $e->description,
+                'total_amount'     => $this->money($e->total_amount),
+                'payer_id'         => $e->payer_id,
+                'group_id'         => $e->group_id,
+                'ticket_image_url' => $e->ticket_image_url,
+                'ocr_status'       => $e->ocr_status,
+                'status'           => $e->status,
+                'expense_date'     => optional($e->expense_date)->toDateString(),
+                'participants'     => $participants,
+                'role'             => $e->payer_id === $userId ? 'payer' : 'participant',
+            ];
+        });
+
+        return [
+            'filters' => [
+                'groupId'   => $groupId,
+                'startDate' => $start?->toDateString(),
+                'endDate'   => $end?->toDateString(),
+            ],
+            'data' => $data,
+            'pagination' => [
+                'current_page' => $items->currentPage(),
+                'per_page'     => $items->perPage(),
+                'total'        => $items->total(),
+                'last_page'    => $items->lastPage(),
+            ],
+        ];
+    }
+
+    public function createExpense(string $userId, array $data): array
+    {
+        $this->assertGroupMembershipOrFail($userId, $data['group_id']);
+        $uniqueUserIds = collect($data['participants'])->pluck('user_id')->unique();
+        foreach ($uniqueUserIds as $uid) {
+            $this->assertGroupMembershipOrFail($uid, $data['group_id']);
+        }
+
+        $sum = collect($data['participants'])->sum(fn($p) => (float)$p['amount_due']);
+        if ($this->money($sum) !== $this->money($data['total_amount'])) {
+            throw ValidationException::withMessages([
+                'participants' => ['La suma de amount_due no coincide con total_amount.'],
+            ]);
+        }
+
+        $hasTicket = (bool) $data['has_ticket'];
+        $ticketUrl = $hasTicket ? ($data['ticket_image_url'] ?? null) : null;
+        $ocrStatus = $hasTicket ? 'pending' : 'skipped';
+
+        $expense = DB::transaction(function () use ($data, $userId, $ticketUrl, $ocrStatus) {
+            $expense = Expense::create([
+                'id'               => (string) Str::uuid(),
+                'description'      => $data['description'],
+                'total_amount'     => $data['total_amount'],
+                'payer_id'         => $userId,
+                'group_id'         => $data['group_id'],
+                'ticket_image_url' => $ticketUrl,
+                'ocr_status'       => $ocrStatus,
+                'ocr_raw_text'     => null,
+                'status'           => 'pending',
+                'expense_date'     => $data['expense_date'],
+            ]);
+
+            $rows = [];
+            foreach ($data['participants'] as $p) {
+                $rows[] = [
+                    'id'         => (string) Str::uuid(),
+                    'user_id'    => $p['user_id'],
+                    'amount_due' => $p['amount_due'],
+                    'is_paid'    => false,
+                    'payment_id' => null,
+                ];
+            }
+            $expense->participants()->createMany($rows);
+
+            return $expense;
+        });
+
+        if ($hasTicket && $ticketUrl) {
+            ProcessExpenseOcr::dispatch($expense->id);
+        }
+
+        return [
+            'message' => 'Gasto creado',
+            'expense' => $this->formatExpense($expense),
+        ];
+    }
+
+    private function assertGroupMembershipOrFail(string $userId, string $groupId): void
+    {
+        $exists = DB::table('group_members')
+            ->where('group_id', $groupId)
+            ->where('user_id', $userId)
+            ->exists();
+
+        if (!$exists) {
+            throw ValidationException::withMessages([
+                'group_id' => ['El usuario no pertenece al grupo especificado.'],
+            ]);
+        }
+    }
+
+    private function formatExpense(Expense $e): array
+    {
+        return [
+            'id'               => $e->id,
+            'description'      => $e->description,
+            'total_amount'     => $this->money($e->total_amount),
+            'payer_id'         => $e->payer_id,
+            'group_id'         => $e->group_id,
+            'ticket_image_url' => $e->ticket_image_url,
+            'ocr_status'       => $e->ocr_status,
+            'status'           => $e->status,
+            'expense_date'     => optional($e->expense_date)->toDateString(),
+            'created_at'       => $e->created_at,
+            'updated_at'       => $e->updated_at,
+        ];
+    }
+
+    private function money($value): string
+    {
+        return number_format((float) ($value ?? 0), 2, '.', '');
+    }
+}

--- a/app/Services/PaymentService.php
+++ b/app/Services/PaymentService.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Payment;
+use Carbon\Carbon;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class PaymentService
+{
+    public function listPayments(string $userId, ?string $status, ?string $direction, ?string $groupId, ?Carbon $start, ?Carbon $end): array
+    {
+        $query = Payment::with(['payer', 'receiver'])
+            ->when($direction === 'incoming', fn($q) => $q->where('to_user_id', $userId))
+            ->when($direction === 'outgoing', fn($q) => $q->where('from_user_id', $userId))
+            ->when(!$direction, function ($q) use ($userId) {
+                $q->where(function ($w) use ($userId) {
+                    $w->where('from_user_id', $userId)->orWhere('to_user_id', $userId);
+                });
+            })
+            ->when($status, fn($q) => $q->where('status', $status))
+            ->when($groupId, fn($q) => $q->where('group_id', $groupId))
+            ->when($start, fn($q) => $q->whereRaw('COALESCE(payment_date, created_at) >= ?', [$start->toDateTimeString()]))
+            ->when($end, fn($q) => $q->whereRaw('COALESCE(payment_date, created_at) <= ?', [$end->toDateTimeString()]))
+            ->orderByDesc(DB::raw('COALESCE(payment_date, created_at)'));
+
+        /** @var LengthAwarePaginator $items */
+        $items = $query->paginate(15);
+
+        $data = $items->getCollection()->map(function (Payment $p) use ($userId) {
+            return $this->formatPaymentRow($p, $userId);
+        });
+
+        return [
+            'filters' => [
+                'status'    => $status,
+                'direction' => $direction,
+                'groupId'   => $groupId,
+                'startDate' => $start?->toDateString(),
+                'endDate'   => $end?->toDateString(),
+            ],
+            'data' => $data,
+            'pagination' => [
+                'current_page' => $items->currentPage(),
+                'per_page'     => $items->perPage(),
+                'total'        => $items->total(),
+                'last_page'    => $items->lastPage(),
+            ],
+        ];
+    }
+
+    public function createPayment(string $userId, array $data): array
+    {
+        if ($data['from_user_id'] !== $userId) {
+            throw ValidationException::withMessages([
+                'from_user_id' => ['No puedes crear pagos a nombre de otro usuario'],
+            ]);
+        }
+
+        $members = DB::table('group_members')
+            ->where('group_id', $data['group_id'])
+            ->whereIn('user_id', [$data['from_user_id'], $data['to_user_id']])
+            ->count();
+        if ($members < 2) {
+            throw ValidationException::withMessages([
+                'group_id' => ['Ambos usuarios deben pertenecer al grupo'],
+            ]);
+        }
+
+        $payment = DB::transaction(function () use ($data) {
+            $payment = Payment::create([
+                'id'             => (string) Str::uuid(),
+                'group_id'       => $data['group_id'],
+                'from_user_id'   => $data['from_user_id'],
+                'to_user_id'     => $data['to_user_id'],
+                'amount'         => $data['amount'],
+                'note'           => $data['note'] ?? null,
+                'evidence_url'   => $data['evidence_url'] ?? null,
+                'payment_method' => $data['payment_method'] ?? null,
+                'status'         => 'pending',
+                'created_at'     => now(),
+                'updated_at'     => now(),
+            ]);
+
+            return $payment->load(['payer', 'receiver']);
+        });
+
+        return [
+            'message' => 'Payment created',
+            'payment' => $this->formatPaymentRow($payment, $userId),
+        ];
+    }
+
+    private function formatPaymentRow(Payment $p, string $currentUserId): array
+    {
+        $direction = $p->from_user_id === $currentUserId ? 'outgoing' :
+            ($p->to_user_id === $currentUserId ? 'incoming' : 'other');
+
+        return [
+            'id'               => $p->id,
+            'group_id'         => $p->group_id,
+            'amount'           => $this->money($p->amount),
+            'status'           => $p->status,
+            'payment_date'     => $p->payment_date,
+            'payment_method'   => $p->payment_method,
+            'note'             => $p->note,
+            'evidence_url'     => $p->evidence_url,
+            'from_user_id'     => $p->from_user_id,
+            'payer_name'       => $p->payer?->name,
+            'to_user_id'       => $p->to_user_id,
+            'receiver_name'    => $p->receiver?->name,
+            'direction'        => $direction,
+            'unapplied_amount' => $this->money($p->unapplied_amount ?? 0),
+        ];
+    }
+
+    private function money($value): string
+    {
+        return number_format((float) ($value ?? 0), 2, '.', '');
+    }
+}


### PR DESCRIPTION
## Summary
- add `ExpenseService` and `PaymentService` to encapsulate database operations with Eloquent
- refactor expense and payment controllers to delegate listing and creation to services

## Testing
- `php -l app/Services/ExpenseService.php app/Services/PaymentService.php app/Http/Controllers/Api/ExpenseController.php app/Http/Controllers/Api/PaymentController.php`
- `composer test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68ba2f4981048324a279f0fecaad6afc