### PR TITLE
Add profile picture URL support to groups

### DIFF
--- a/app/Http/Controllers/Api/GroupController.php
+++ b/app/Http/Controllers/Api/GroupController.php
@@ -37,6 +37,7 @@ class GroupController extends Controller
                  g.name,
                  g.description,
                  g.owner_id,
+                 g.profile_picture_url,
                  g.created_at,
                  COALESCE(gm.role::text, CASE WHEN g.owner_id = ? THEN 'owner' END) AS my_role,
                  (SELECT COUNT(*) FROM group_members m WHERE m.group_id = g.id) AS members_count",
@@ -51,6 +52,7 @@ class GroupController extends Controller
                     'description'   => $g->description,
                     'owner_id'      => $g->owner_id,
                     'created_at'    => $g->created_at,
+                    'profile_picture_url' => $g->profile_picture_url ?? $this->defaultProfilePictureUrl($g->name),
                     'my_role'       => $g->my_role ?? 'member',
                     'members_count' => (int) $g->members_count,
                 ];
@@ -77,6 +79,7 @@ class GroupController extends Controller
                 'id'          => $groupId,
                 'name'        => $data['name'],
                 'description' => $data['description'] ?? null,
+                'profile_picture_url' => $data['profile_picture_url'] ?? null,
                 'owner_id'    => $userId,
                 // created_at: lo define la BD si tienes default; si no, usa now()
             ]);
@@ -382,6 +385,13 @@ class GroupController extends Controller
             'description' => $g->description,
             'owner_id'    => $g->owner_id,
             'created_at'  => $g->created_at ?? null,
+            'profile_picture_url' => $g->profile_picture_url ?? $this->defaultProfilePictureUrl($g->name),
         ];
+    }
+
+    private function defaultProfilePictureUrl(string $name): string
+    {
+        $seed = urlencode($name);
+        return "https://api.dicebear.com/7.x/initials/svg?seed={$seed}";
     }
 }

--- a/app/Http/Requests/Group/StoreGroupRequest.php
+++ b/app/Http/Requests/Group/StoreGroupRequest.php
@@ -24,6 +24,7 @@ class StoreGroupRequest extends FormRequest
         return [
             'name'        => ['required', 'string', 'max:150'],
             'description' => ['sometimes', 'nullable', 'string'],
+            'profile_picture_url' => ['sometimes', 'nullable', 'url'],
         ];
     }
 }

--- a/app/Http/Requests/Group/UpdateGroupRequest.php
+++ b/app/Http/Requests/Group/UpdateGroupRequest.php
@@ -24,6 +24,7 @@ class UpdateGroupRequest extends FormRequest
         return [
             'name'        => ['sometimes', 'string', 'max:150'],
             'description' => ['sometimes', 'nullable', 'string'],
+            'profile_picture_url' => ['sometimes', 'nullable', 'url'],
         ];
     }
 }

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -20,6 +20,7 @@ class Group extends Model
         'description',
         'owner_id',
         'created_at',
+        'profile_picture_url',
     ];
 
     public function owner()

--- a/database/migrations/2025_09_03_000000_add_profile_picture_url_to_groups_table.php
+++ b/database/migrations/2025_09_03_000000_add_profile_picture_url_to_groups_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->string('profile_picture_url')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->dropColumn('profile_picture_url');
+        });
+    }
+};

--- a/docs/API.md
+++ b/docs/API.md
@@ -50,7 +50,8 @@ POST /api/auth/login
 POST /api/groups
 {
   "name": "Viaje",
-  "description": "Gastos del viaje"
+  "description": "Gastos del viaje",
+  "profile_picture_url": "https://example.com/logo.png"
 }
 ```
 #### Respuesta
@@ -58,9 +59,12 @@ POST /api/groups
 {
   "id": "UUID",
   "name": "Viaje",
-  "description": "Gastos del viaje"
+  "description": "Gastos del viaje",
+  "profile_picture_url": "https://example.com/logo.png"
 }
 ```
+
+Si no se envía `profile_picture_url`, la API genera automáticamente un avatar por defecto basado en el nombre del grupo mediante DiceBear.
 
 ### Invitaciones - Crear invitación
 #### Solicitud

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -216,11 +216,16 @@ paths:
                   type: string
                 description:
                   type: string
+                profile_picture_url:
+                  type: string
+                  format: uri
+                  description: URL de la imagen de perfil del grupo. Si se omite, se genera un avatar por defecto.
             examples:
               create:
                 value:
                   name: Viaje a Madrid
                   description: Gastos del viaje de mayo
+                  profile_picture_url: https://example.com/logo.png
       responses:
         '201':
           description: Grupo creado
@@ -232,6 +237,7 @@ paths:
                     id: 11111111-2222-3333-4444-555555555555
                     name: Viaje a Madrid
                     description: Gastos del viaje de mayo
+                    profile_picture_url: https://example.com/logo.png
   /groups/{group}:
     parameters:
       - in: path
@@ -258,9 +264,13 @@ paths:
                   type: string
                 description:
                   type: string
+                profile_picture_url:
+                  type: string
+                  format: uri
             example:
               name: Nuevo nombre
               description: Descripción actualizada
+              profile_picture_url: https://example.com/nuevo.png
       responses:
         '200':
           description: Grupo actualizado

--- a/tests/Feature/GroupControllerTest.php
+++ b/tests/Feature/GroupControllerTest.php
@@ -21,6 +21,7 @@ class GroupControllerTest extends TestCase
         $response = $this->postJson('/api/groups', [
             'name' => 'Mi Grupo',
             'description' => 'Descripcion',
+            'profile_picture_url' => 'https://example.com/pic.png',
         ]);
 
         $response->assertStatus(201)
@@ -30,6 +31,7 @@ class GroupControllerTest extends TestCase
                     'name' => 'Mi Grupo',
                     'description' => 'Descripcion',
                     'owner_id' => $user->id,
+                    'profile_picture_url' => 'https://example.com/pic.png',
                 ],
             ]);
     }
@@ -50,6 +52,7 @@ class GroupControllerTest extends TestCase
 
         $response = $this->putJson('/api/groups/' . $group->id, [
             'description' => 'Actualizado',
+            'profile_picture_url' => 'https://example.com/updated.png',
         ]);
 
         $response->assertStatus(200)
@@ -58,7 +61,59 @@ class GroupControllerTest extends TestCase
                 'group' => [
                     'id' => $group->id,
                     'description' => 'Actualizado',
+                    'profile_picture_url' => 'https://example.com/updated.png',
                 ],
             ]);
+    }
+
+    public function test_group_retrieval_returns_fallback_profile_picture_url_when_missing(): void
+    {
+        $user = User::factory()->create();
+        $group = Group::factory()->create(['owner_id' => $user->id, 'profile_picture_url' => null]);
+        DB::table('group_members')->insert([
+            'id' => (string) Str::uuid(),
+            'group_id' => $group->id,
+            'user_id' => $user->id,
+            'role' => 'owner',
+            'joined_at' => now(),
+        ]);
+
+        $this->actingAs($user, 'sanctum');
+
+        $expected = 'https://api.dicebear.com/7.x/initials/svg?seed=' . urlencode($group->name);
+
+        $this->getJson('/api/groups')
+            ->assertStatus(200)
+            ->assertJsonPath('data.0.profile_picture_url', $expected);
+
+        $this->getJson('/api/groups/' . $group->id)
+            ->assertStatus(200)
+            ->assertJsonPath('group.profile_picture_url', $expected);
+    }
+
+    public function test_group_retrieval_returns_custom_profile_picture_url_when_present(): void
+    {
+        $user = User::factory()->create();
+        $group = Group::factory()->create([
+            'owner_id' => $user->id,
+            'profile_picture_url' => 'https://example.com/custom.png',
+        ]);
+        DB::table('group_members')->insert([
+            'id' => (string) Str::uuid(),
+            'group_id' => $group->id,
+            'user_id' => $user->id,
+            'role' => 'owner',
+            'joined_at' => now(),
+        ]);
+
+        $this->actingAs($user, 'sanctum');
+
+        $this->getJson('/api/groups')
+            ->assertStatus(200)
+            ->assertJsonPath('data.0.profile_picture_url', 'https://example.com/custom.png');
+
+        $this->getJson('/api/groups/' . $group->id)
+            ->assertStatus(200)
+            ->assertJsonPath('group.profile_picture_url', 'https://example.com/custom.png');
     }
 }


### PR DESCRIPTION
## Summary
- allow groups to store an optional `profile_picture_url`
- serve a DiceBear-based default avatar when not provided
- document profile picture field and behavior

## Testing
- `phpunit` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba466a06908324a3334abfea1f8dc9