### PR TITLE
Use `mode` key for app mode response

### DIFF
--- a/app/Http/Controllers/Api/AppModeController.php
+++ b/app/Http/Controllers/Api/AppModeController.php
@@ -10,7 +10,7 @@ class AppModeController extends Controller
     public function show(): JsonResponse
     {
         return response()->json([
-            'mode_app' => config('app.mode_app'),
+            'mode' => config('app.mode_app'),
         ]);
     }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -10,7 +10,7 @@ La aplicación opera en dos modos controlados por la variable de entorno `MODE_A
 Para cambiar el modo edita el archivo `.env`, ajusta `MODE_APP` y ejecuta `php artisan config:clear`.
 
 ### GET /api/app-mode
-Devuelve el modo actual de la aplicación (`public` o `private`).
+Devuelve el modo actual de la aplicación (`public` o `private`) en la clave `mode`.
 No requiere autenticación.
 
 #### Respuesta

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -21,7 +21,7 @@ paths:
   /app-mode:
     get:
       summary: Obtiene el modo actual de la aplicación
-      description: Devuelve `public` o `private`
+      description: Devuelve `public` o `private` en la clave `mode`
       security: []
       responses:
         '200':

--- a/tests/Feature/AppModeControllerTest.php
+++ b/tests/Feature/AppModeControllerTest.php
@@ -13,7 +13,7 @@ class AppModeControllerTest extends TestCase
         $response = $this->getJson('/api/app-mode');
 
         $response->assertStatus(200)
-            ->assertExactJson(['mode_app' => 'private']);
+            ->assertExactJson(['mode' => 'private']);
     }
 
     public function test_show_returns_public_mode(): void
@@ -23,7 +23,7 @@ class AppModeControllerTest extends TestCase
         $response = $this->getJson('/api/app-mode');
 
         $response->assertStatus(200)
-            ->assertExactJson(['mode_app' => 'public']);
+            ->assertExactJson(['mode' => 'public']);
     }
 }
 


### PR DESCRIPTION
## Summary
- return app mode under `mode` key
- document the new `mode` key in API examples
- adjust tests for new response shape

## Testing
- `composer test` *(fails: @php artisan config:clear --ansi handling the test event returned with error code 255)*
- `composer install` *(fails: Failed to download guzzlehttp/psr7 from dist: curl error 56 while downloading https://api.github.com/repos/guzzle/psr7/zipball/...: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4b66aaa88324ac137224eed3be0a