### PR TITLE
doc: detail device registration responses

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -149,11 +149,23 @@ POST /api/notifications/register-device
 }
 ```
 #### Respuesta
+- **201** cuando se inserta un nuevo token.
 ```json
 {
-  "message": "Dispositivo registrado"
+  "message": "Dispositivo registrado",
+  "device": {
+    "id": "UUID",
+    "user_id": "UUID",
+    "device_token": "token-ejemplo",
+    "device_type": "web"
+  },
+  "stats": {
+    "total_devices_for_user": 1
+  }
 }
 ```
+
+- **200** cuando el token ya existía. El mensaje puede ser `Dispositivo actualizado` o `Dispositivo ya estaba registrado`.
 
 ## Flujo de registro e invitaciones
 
@@ -449,6 +461,12 @@ Registra o actualiza un dispositivo para recibir notificaciones.
 **Body**
 - `device_token` (string, requerido)
 - `device_type` (`android`|`ios`|`web`, requerido)
+
+**Respuesta**
+- `message`: "Dispositivo registrado" (201) o "Dispositivo actualizado"/"Dispositivo ya estaba registrado" (200).
+- `device` (objeto): contiene `id`, `user_id`, `device_token` y `device_type`.
+- `stats` (objeto): incluye `total_devices_for_user` (número de dispositivos del usuario).
+- Una nueva inserción responde **201** y una actualización **200**.
 
 ## Dashboard
 

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -809,14 +809,97 @@ paths:
                   device_token: TOKEN123
                   device_type: android
       responses:
-        '200':
+        '201':
           description: Dispositivo registrado
           content:
             application/json:
+              schema:
+                type: object
+                required: [message, device, stats]
+                properties:
+                  message:
+                    type: string
+                  device:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      user_id:
+                        type: string
+                        format: uuid
+                      device_token:
+                        type: string
+                      device_type:
+                        type: string
+                        enum: [android, ios, web]
+                  stats:
+                    type: object
+                    properties:
+                      total_devices_for_user:
+                        type: integer
               examples:
-                success:
+                created:
                   value:
                     message: Dispositivo registrado
+                    device:
+                      id: 11111111-2222-3333-4444-555555555555
+                      user_id: 99999999-aaaa-bbbb-cccc-dddddddddddd
+                      device_token: TOKEN123
+                      device_type: android
+                    stats:
+                      total_devices_for_user: 1
+        '200':
+          description: Dispositivo actualizado o ya estaba registrado
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [message, device, stats]
+                properties:
+                  message:
+                    type: string
+                    enum: [Dispositivo actualizado, Dispositivo ya estaba registrado]
+                  device:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      user_id:
+                        type: string
+                        format: uuid
+                      device_token:
+                        type: string
+                      device_type:
+                        type: string
+                        enum: [android, ios, web]
+                  stats:
+                    type: object
+                    properties:
+                      total_devices_for_user:
+                        type: integer
+              examples:
+                updated:
+                  value:
+                    message: Dispositivo actualizado
+                    device:
+                      id: 11111111-2222-3333-4444-555555555555
+                      user_id: 99999999-aaaa-bbbb-cccc-dddddddddddd
+                      device_token: TOKEN123
+                      device_type: android
+                    stats:
+                      total_devices_for_user: 1
+                alreadyRegistered:
+                  value:
+                    message: Dispositivo ya estaba registrado
+                    device:
+                      id: 11111111-2222-3333-4444-555555555555
+                      user_id: 99999999-aaaa-bbbb-cccc-dddddddddddd
+                      device_token: TOKEN123
+                      device_type: android
+                    stats:
+                      total_devices_for_user: 1
   /dashboard/summary:
     get:
       summary: Resumen de deudas, pagos y actividad reciente


### PR DESCRIPTION
## Summary
- describe `device` and `stats` fields in notification device registration
- document 201 vs 200 responses and new messages

## Testing
- `composer test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4b6795bc8324a27a2d9438752fbd