### PR TITLE
docs: describe optional signature field for payment update

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -748,11 +748,14 @@ paths:
                 evidence_url:
                   type: string
                   format: uri
+                signature:
+                  type: string
             examples:
               update:
                 value:
                   payment_method: cash
                   evidence_url: https://example.com/comprobante.jpg
+                  signature: Pago aprobado
       responses:
         '200':
           description: Pago actualizado
@@ -763,6 +766,7 @@ paths:
                   value:
                     id: 44444444-5555-6666-7777-888888888888
                     status: pending
+                    signature: Pago aprobado
   /payments/{id}/approve:
     parameters:
       - in: path


### PR DESCRIPTION
## Summary
- document optional `signature` field for updating a payment

## Testing
- `composer test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: CONNECT tunnel 403 requiring GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4b68b0e08324b7e9e1a1df5260a5