### PR TITLE
docs: clarify profile picture field

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -224,6 +224,8 @@ Registra un usuario utilizando un token de registro.
 - `profile_picture_url` (url, opcional)
 - `phone_number` (string, opcional)
 
+Si se omite `profile_picture_url`, la API genera un avatar por defecto.
+
 ### POST /api/auth/login
 Inicia sesión y devuelve un token Sanctum. Usuarios desactivados no pueden iniciar sesión.
 Limitado a **5 intentos por minuto** por combinación de IP y correo.


### PR DESCRIPTION
## Summary
- note that `profile_picture_url` is optional when registering and defaults to an auto-generated avatar

## Testing
- `composer test` *(fails: require(/workspace/gestion-financiera/vendor/autoload.php): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4b6920908324976e2ceb784b3d03