### PR TITLE
docs: detail PHP/Node requirements and dev workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ recurrentes personales.
 
 Este proyecto utiliza **PostgreSQL** como motor de base de datos.
 
+Requisitos previos:
+
+- PHP >= 8.2
+- Node.js >= 20 (recomendado)
+
 1. Clonar el repositorio y entrar al directorio del proyecto.
 2. Instalar dependencias de PHP y JavaScript:
    ```bash
@@ -24,10 +29,27 @@ Este proyecto utiliza **PostgreSQL** como motor de base de datos.
    ```bash
    php artisan migrate
    ```
-5. Levantar el servidor de desarrollo:
+5. Levantar el servidor de desarrollo del backend:
    ```bash
    php artisan serve
    ```
+6. En otra terminal, iniciar el entorno front-end:
+   ```bash
+   npm run dev
+   ```
+   También puedes utilizar el comando:
+   ```bash
+   composer dev
+   ```
+   que levanta servidor, cola y Vite simultáneamente.
+
+Para ejecutar la suite de pruebas:
+
+```bash
+php artisan test
+# o
+composer test
+```
 
 ### PostgreSQL con Docker Compose
 
@@ -118,6 +140,7 @@ Que devuelve un JSON con la forma:
 | `php artisan queue:listen` | Procesa trabajos en la cola.                     |
 | `npm run dev`              | Compila activos front‑end con Vite.              |
 | `php artisan test`         | Ejecuta la suite de pruebas.                     |
+| `composer test`            | Alias para ejecutar la suite de pruebas.        |
 
 ## Notificaciones Push
 


### PR DESCRIPTION
## Summary
- document minimum PHP 8.2 and recommended Node.js 20
- add instructions for npm run dev or composer dev
- note how to execute tests via php artisan test or composer test

## Testing
- `composer test` *(fails: require vendor/autoload.php; composer install requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5b41324c8324a505221a7c8c23d9