### PR TITLE
chore: pin Node 20 for frontend build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
 # syntax=docker/dockerfile:1
+
+# Build front-end assets with a fixed Node version
+FROM node:20 AS frontend
+WORKDIR /app
+COPY package*.json vite.config.js ./
+COPY resources ./resources
+RUN npm install && npm run build
+
 # Use PHP 8.2 FPM as base image
 FROM php:8.2-fpm
 
@@ -16,8 +24,6 @@ RUN apt-get update && apt-get install -y \
     libonig-dev \
     libxml2-dev \
     libpq-dev \
-    nodejs \
-    npm \
  && rm -rf /var/lib/apt/lists/*
 
 # PHP extensions
@@ -29,18 +35,19 @@ COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 # Workdir
 WORKDIR /var/www
 
-# Copia (en desarrollo será sobrescrita por el bind mount de docker-compose)
+# Copy application source
 COPY . /var/www
 
-# Instala dependencias PHP SIN scripts (evita correr Artisan en build)
+# Copy built assets from the Node stage
+COPY --from=frontend /app/public/build /var/www/public/build
+
+# Install PHP dependencies without running scripts (avoids Artisan during build)
 RUN composer install --no-interaction --no-dev --prefer-dist --optimize-autoloader --no-scripts || true
 
-# Build de front solo si hay package.json
-RUN [ -f package.json ] && npm install && npm run build || true
-
-# Permisos
+# Permissions
 RUN chown -R www-data:www-data /var/www/storage /var/www/bootstrap/cache
 
 # PHP-FPM
 EXPOSE 9000
 CMD ["php-fpm"]
+

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ Ejecutar con:
 docker compose up -d db
 ```
 
+### Build del front-end con Docker
+
+El `Dockerfile` usa una etapa de construcción basada en `node:20` para compilar los activos
+front‑end con Vite. De esta forma se fija la versión de Node utilizada y se evita instalar
+Node en la imagen final. Al actualizar los archivos de `resources` es necesario volver a
+construir la imagen para regenerar `public/build`.
+
 ## Configuración del `.env`
 
 Variables principales:


### PR DESCRIPTION
## Summary
- build assets using node:20 stage and remove node from final image
- document Docker front-end build process in README

## Testing
- `npm run build`
- `composer test` *(fails: Failed to open vendor autoload; composer install requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5b55ebd48324b704702f780deef6